### PR TITLE
Update patches for Claude Code 2.0.69

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Claude Code collapses thinking blocks by default, showing only:
 
 You have to press `ctrl+o` every time to see the actual thinking content. This patch makes thinking blocks visible inline automatically.
 
-**Current Version:** Claude Code 2.0.62 (Updated 2025-12-09)
+**Current Version:** Claude Code 2.0.69 (Updated 2025-12-15)
 
 ## Quick Start
 
@@ -108,6 +108,7 @@ function GkQ({streamMode:A}){return null}
 - v2.0.59: Renamed to `DO2`, uses `MP.createElement`, `CRA.useState`
 - v2.0.61: Renamed to `RR2`, uses `rj.createElement`, `vTA.useState`, `P` container
 - v2.0.62: Renamed to `ZT2`, uses `GP.createElement`, `rTA.useState`, `P` container
+- v2.0.69: Renamed to `KnB`, uses `GT.createElement`, `hLA.useState`, `j` container, `z` text component
 
 ### Patch 2: Force Thinking Visibility (v2.0.46)
 **Before:**
@@ -153,11 +154,12 @@ case"thinking":
 - v2.0.59: Changed to `F89` component, `u3` variable, checks `K` and `G`
 - v2.0.61: Changed to `T69` component, `A3` variable, checks `F` and `G`
 - v2.0.62: Changed to `X59` component, `J3` variable, checks `F` and `G`
+- v2.0.69: Changed to `sU2` component, `n8` variable, checks `E` and `G`
 
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.0.62 installed
+- Claude Code v2.0.69 installed
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -265,18 +267,18 @@ Then restart Claude Code.
 
 ## Verification
 
-Check if patches are applied (for v2.0.62):
+Check if patches are applied (for v2.0.69):
 
 ```bash
-# Check ZT2 patch
-grep -n "function ZT2" ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
+# Check KnB patch
+grep -n "function KnB" ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
 
-# Should show: function ZT2({streamMode:A}){return null}
+# Should show: function KnB({streamMode:A}){return null}
 
 # Check thinking visibility patch
-grep -n 'case"thinking":return J3.createElement(X59' ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
+grep -n 'case"thinking":return n8.createElement(sU2' ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
 
-# Should show: case"thinking":return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
+# Should show: case"thinking":return n8.createElement(sU2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
 ```
 
 ## Troubleshooting
@@ -380,8 +382,8 @@ The script automatically works with all Node.js version managers:
 ## Technical Details
 
 ### File Structure
-- **cli.js:** ~3,600+ lines, ~9+ MB (heavily minified)
-- **Version:** Claude Code 2.0.46
+- **cli.js:** ~3,600+ lines, ~10+ MB (heavily minified)
+- **Version:** Claude Code 2.0.69
 - **Patches:** Non-invasive, minimal changes
 
 ### Installation Detection System
@@ -411,11 +413,11 @@ $(which claude) → resolve symlinks → find cli.js
 
 ### Why Two Patches?
 
-1. **ZT2 Function:** Controls the UI banner shown after thinking completes
+1. **KnB Function:** Controls the UI banner shown after thinking completes
 2. **Thinking Renderer:** Controls whether the actual thinking text is displayed
 
 Both must be patched because they're separate systems:
-- Patching only ZT2 → Blank line appears where thinking should be
+- Patching only KnB → Blank line appears where thinking should be
 - Patching only the renderer → Banner still shows "ctrl+o to show"
 
 ### Pattern Evolution Across Versions
@@ -452,6 +454,7 @@ The minified code patterns change with each Claude Code update:
 | 2.0.59  | `DO2`          | `F89`     | `K,G` check |
 | 2.0.61  | `RR2`          | `T69`     | `F,G` check |
 | 2.0.62  | `ZT2`          | `X59`     | `F,G` check |
+| 2.0.69  | `KnB`          | `sU2`     | `E,G` check |
 
 When Claude Code updates, function names and component identifiers are regenerated during minification. In some cases (like v2.0.29), the patterns remain unchanged.
 
@@ -460,7 +463,7 @@ When Claude Code updates, function names and component identifiers are regenerat
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.0.62
+4. **Version-specific:** Patterns are specific to v2.0.69
 
 ## Feature Request
 
@@ -497,9 +500,9 @@ Configure which AI models Claude Code uses for different subagent types (Plan, E
 ### The Problem
 
 By default, Claude Code hardcodes the models used by subagents:
-- **Plan subagent**: Uses Sonnet (for planning tasks)
+- **Plan subagent**: Uses "inherit" (inherits from main loop model)
 - **Explore subagent**: Uses Haiku (for code exploration)
-- **general-purpose subagent**: Inherits from main loop model
+- **general-purpose subagent**: Uses Sonnet
 
 You cannot change these defaults without modifying the source code.
 
@@ -507,7 +510,7 @@ You cannot change these defaults without modifying the source code.
 
 This patch allows you to configure subagent models via a configuration file (`~/.claude/subagent-models.json`).
 
-**Current Version:** Claude Code 2.0.46
+**Current Version:** Claude Code 2.0.69
 
 ### Quick Start
 
@@ -569,22 +572,28 @@ node patch-subagent-models.js --help
 
 The patch modifies Claude Code's `cli.js` to change the hardcoded model assignments:
 
-**Before (v2.0.37):**
+**Before (v2.0.69):**
 ```javascript
-// Plan subagent
-R3A={agentType:"Plan",...,model:"sonnet"}
+// Plan subagent (JJA)
+JJA={agentType:"Plan",...,model:"inherit"}
 
-// Explore subagent
-model:"haiku"}});var R3A;
+// Explore subagent (uw)
+uw={agentType:"Explore",...,model:"haiku"}
+
+// general-purpose subagent (MB1)
+MB1={agentType:"general-purpose",...,model:"sonnet"}
 ```
 
-**After (with config: Plan="haiku", Explore="sonnet"):**
+**After (with config: Plan="sonnet", Explore="sonnet", general-purpose="opus"):**
 ```javascript
 // Plan subagent
-R3A={agentType:"Plan",...,model:"haiku"}
+JJA={agentType:"Plan",...,model:"sonnet"}
 
 // Explore subagent
-model:"sonnet"}});var R3A;
+uw={agentType:"Explore",...,model:"sonnet"}
+
+// general-purpose subagent
+MB1={agentType:"general-purpose",...,model:"opus"}
 ```
 
 ### Important Notes
@@ -599,7 +608,7 @@ model:"sonnet"}});var R3A;
    ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js.subagent-models.backup
    ```
 
-3. **Version-Specific:** Patterns are specific to v2.0.37. May need updates for newer versions.
+3. **Version-Specific:** Patterns are specific to v2.0.69. May need updates for newer versions.
 
 ### Restoration
 
@@ -660,11 +669,12 @@ cp ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js.subagent-models
 
 ### Version History
 
-| Version | Plan Default | Explore Default | Notes |
-|---------|-------------|-----------------|-------|
-| 2.0.31  | sonnet      | haiku           | Previous |
-| 2.0.32  | sonnet      | haiku           | Previous |
-| 2.0.37  | sonnet      | haiku           | Current |
+| Version | Plan Default | Explore Default | general-purpose Default | Notes |
+|---------|-------------|-----------------|------------------------|-------|
+| 2.0.31  | sonnet      | haiku           | (inherited)            | Previous |
+| 2.0.32  | sonnet      | haiku           | (inherited)            | Previous |
+| 2.0.37  | sonnet      | haiku           | (inherited)            | Previous |
+| 2.0.69  | inherit     | haiku           | sonnet                 | Current |
 
 ---
 
@@ -678,8 +688,8 @@ Developed through analysis of Claude Code's compiled JavaScript. Special thanks 
 
 ---
 
-**Last Updated:** 2025-12-09
-**Claude Code Version:** 2.0.62
+**Last Updated:** 2025-12-15
+**Claude Code Version:** 2.0.69
 **Status:** ✅ Working
 
 ### Quick Reference

--- a/patch-subagent-models.js
+++ b/patch-subagent-models.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Subagent Model Configuration Patcher v2.0.33');
+  console.log('Claude Code Subagent Model Configuration Patcher v2.0.69');
   console.log('=========================================================\n');
   console.log('Usage: node patch-subagent-models.js [options]\n');
   console.log('Options:');
@@ -34,7 +34,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Subagent Model Configuration Patcher v2.0.33');
+console.log('Claude Code Subagent Model Configuration Patcher v2.0.69');
 console.log('=========================================================\n');
 
 // Helper function to safely execute shell commands
@@ -222,47 +222,52 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Define patch patterns for v2.0.33
+// Define patch patterns for v2.0.69
+// Note: In v2.0.69, the structure changed significantly:
+// - Plan agent (JJA): default model is now "inherit" instead of "sonnet"
+// - Explore agent (uw): still defaults to "haiku"
+// - general-purpose agent (MB1): defaults to "sonnet"
+// All agents now have getSystemPrompt and criticalSystemReminder_EXPERIMENTAL properties
 const patches = [];
 
-// Patch 1: Plan agent (a3A)
+// Patch 1: Plan agent (JJA) - uses regex to find and replace model value
 if (modelConfig.Plan) {
   patches.push({
     name: 'Plan agent model',
-    searchPattern: 'a3A={agentType:"Plan",whenToUse:Sw.whenToUse,disallowedTools:Sw.disallowedTools,systemPrompt:Sw.systemPrompt,source:"built-in",tools:Sw.tools,baseDir:"built-in",model:"sonnet"}',
-    replacement: `a3A={agentType:"Plan",whenToUse:Sw.whenToUse,disallowedTools:Sw.disallowedTools,systemPrompt:Sw.systemPrompt,source:"built-in",tools:Sw.tools,baseDir:"built-in",model:"${modelConfig.Plan}"}`,
-    currentValue: 'sonnet',
+    searchPattern: /JJA=\{agentType:"Plan",[^}]*model:"([^"]+)"[^}]*\}/,
+    isRegex: true,
+    replacePattern: (match, currentModel) => {
+      return match.replace(/,model:"[^"]+"/, `,model:"${modelConfig.Plan}"`);
+    },
+    currentValue: 'inherit',
     newValue: modelConfig.Plan
   });
 }
 
-// Patch 2: Explore agent (Sw) - model appears at end of definition before }});
+// Patch 2: Explore agent (uw) - uses regex to find and replace model value
 if (modelConfig.Explore) {
   patches.push({
     name: 'Explore agent model',
-    searchPattern: 'Complete the user\'s search request efficiently and report your findings clearly.`,source:"built-in",baseDir:"built-in",model:"haiku"}});var a3A;',
-    replacement: 'Complete the user\'s search request efficiently and report your findings clearly.`,source:"built-in",baseDir:"built-in",model:"' + modelConfig.Explore + '"}});var a3A;',
+    searchPattern: /uw=\{agentType:"Explore",[^}]*model:"([^"]+)"[^}]*\}/,
+    isRegex: true,
+    replacePattern: (match, currentModel) => {
+      return match.replace(/,model:"[^"]+"/, `,model:"${modelConfig.Explore}"`);
+    },
     currentValue: 'haiku',
     newValue: modelConfig.Explore
   });
 }
 
-// Patch 3: general-purpose agent (Y01) - this one might not have a model property by default
+// Patch 3: general-purpose agent (MB1) - uses regex to find and replace model value
 if (modelConfig['general-purpose']) {
   patches.push({
     name: 'general-purpose agent model',
-    searchPattern: /Y01=\{agentType:"general-purpose"[^}]*\}/,
+    searchPattern: /MB1=\{agentType:"general-purpose",[^}]*model:"([^"]+)"[^}]*getSystemPrompt/,
     isRegex: true,
-    replacePattern: (match) => {
-      // Check if it already has a model property
-      if (match.includes(',model:"')) {
-        return match.replace(/,model:"[^"]+"/g, `,model:"${modelConfig['general-purpose']}"`);
-      } else {
-        // Add model property before the closing brace
-        return match.replace(/\}$/, `,model:"${modelConfig['general-purpose']}"}`);
-      }
+    replacePattern: (match, currentModel) => {
+      return match.replace(/,model:"[^"]+"/, `,model:"${modelConfig['general-purpose']}"`);
     },
-    currentValue: '(inherited)',
+    currentValue: 'sonnet',
     newValue: modelConfig['general-purpose']
   });
 }

--- a/patch-thinking.js
+++ b/patch-thinking.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Thinking Visibility Patcher v2.0.62');
+  console.log('Claude Code Thinking Visibility Patcher v2.0.69');
   console.log('==============================================\n');
   console.log('Usage: node patch-thinking.js [options]\n');
   console.log('Options:');
@@ -27,7 +27,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Thinking Visibility Patcher v2.0.62');
+console.log('Claude Code Thinking Visibility Patcher v2.0.69');
 console.log('==============================================\n');
 
 // Helper function to safely execute shell commands
@@ -176,15 +176,15 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Patch 1: ZT2 Banner Removal (v2.0.62)
-// Note: Changed from RR2 (v2.0.61) to ZT2 (v2.0.62), rTA/GP namespaces, P container
-const bannerSearchPattern = 'function ZT2({streamMode:A}){let[Q,B]=rTA.useState(null),[G,Z]=rTA.useState(null);if(rTA.useEffect(()=>{if(A==="thinking"&&Q===null)B(Date.now());else if(A!=="thinking"&&Q!==null)Z(Date.now()-Q),B(null)},[A,Q]),A==="thinking")return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thinking…"));if(G!==null)return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thought for ",Math.max(1,Math.round(G/1000)),"s (",GP.createElement($,{dimColor:!0,bold:!0},"ctrl+o")," ","to show thinking)"));return null}';
-const bannerReplacement = 'function ZT2({streamMode:A}){return null}';
+// Patch 1: KnB Banner Removal (v2.0.69)
+// Note: Changed from ZT2 (v2.0.62) to KnB (v2.0.69), hLA/GT namespaces, j container, z text component
+const bannerSearchPattern = 'function KnB({streamMode:A}){let[Q,B]=hLA.useState(null),[G,Z]=hLA.useState(null);if(hLA.useEffect(()=>{if(A==="thinking"&&Q===null)B(Date.now());else if(A!=="thinking"&&Q!==null)Z(Date.now()-Q),B(null)},[A,Q]),A==="thinking")return GT.createElement(j,{marginTop:1},GT.createElement(z,{dimColor:!0},"∴ Thinking…"));if(G!==null)return GT.createElement(j,{marginTop:1},GT.createElement(z,{dimColor:!0},"∴ Thought for ",Math.max(1,Math.round(G/1000)),"s (",GT.createElement(z,{dimColor:!0,bold:!0},"ctrl+o")," ","to show thinking)"));return null}';
+const bannerReplacement = 'function KnB({streamMode:A}){return null}';
 
-// Patch 2: Thinking Visibility (v2.0.62)
-// Note: Changed from T69 (v2.0.61) to X59 (v2.0.62), A3 to J3
-const thinkingSearchPattern = 'case"thinking":if(!F&&!G)return null;return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:F,verbose:G});';
-const thinkingReplacement = 'case"thinking":return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});';
+// Patch 2: Thinking Visibility (v2.0.69)
+// Note: Changed from X59 (v2.0.62) to sU2 (v2.0.69), J3 to n8, F to E
+const thinkingSearchPattern = 'case"thinking":if(!E&&!G)return null;return n8.createElement(sU2,{addMargin:Q,param:A,isTranscriptMode:E,verbose:G});';
+const thinkingReplacement = 'case"thinking":return n8.createElement(sU2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});';
 
 let patch1Applied = false;
 let patch2Applied = false;
@@ -192,7 +192,7 @@ let patch2Applied = false;
 // Check if patches can be applied
 console.log('Checking patches...\n');
 
-console.log('Patch 1: ZT2 banner removal');
+console.log('Patch 1: KnB banner removal');
 if (content.includes(bannerSearchPattern)) {
   patch1Applied = true;
   console.log('  ✅ Pattern found - ready to apply');
@@ -245,7 +245,7 @@ console.log('\nApplying patches...');
 // Apply Patch 1
 if (patch1Applied) {
   content = content.replace(bannerSearchPattern, bannerReplacement);
-  console.log('✅ Patch 1 applied: ZT2 function now returns null');
+  console.log('✅ Patch 1 applied: KnB function now returns null');
 }
 
 // Apply Patch 2


### PR DESCRIPTION
### (forewarning, this is 99% vibecoded, so feel free to close the PR if that's unwanted!)

Thinking Display Patch:
- Banner function: ZT2 → KnB
- useState namespace: rTA → hLA
- createElement namespace: GP → GT
- Container/text components: P/$ → j/z
- Thinking component: X59 → sU2
- Creator variable: J3 → n8
- Check variable: F → E

Subagent Model Patch:
- Plan agent variable: a3A → JJA (default: sonnet → inherit)
- Explore agent variable: Sw → uw (default: haiku, unchanged)
- general-purpose agent variable: Y01 → MB1 (default: inherited → sonnet)
- Updated regex patterns for new agent structure with getSystemPrompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1252" height="1240" alt="image" src="https://github.com/user-attachments/assets/fddfc6c9-eab4-48e2-bd83-83f5375be201" />
