### PR TITLE
Update patch for Claude Code 2.0.71

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ case"thinking":
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.0.71 installed (also works with v2.0.62)
+- Claude Code v2.0.71 installed
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -276,19 +276,6 @@ grep -n 'case"thinking":return b5.createElement(mn2' ~/.claude/local/node_module
 # Should show: case"thinking":return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
 
 # Note: Patch 1 (banner removal) is deprecated in v2.0.71 - no longer needed
-```
-
-For v2.0.62:
-```bash
-# Check ZT2 patch
-grep -n "function ZT2" ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
-
-# Should show: function ZT2({streamMode:A}){return null}
-
-# Check thinking visibility patch
-grep -n 'case"thinking":return J3.createElement(X59' ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
-
-# Should show: case"thinking":return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
 ```
 
 ## Troubleshooting
@@ -475,7 +462,7 @@ When Claude Code updates, function names and component identifiers are regenerat
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.0.71 (also supports v2.0.62)
+4. **Version-specific:** Patterns are specific to v2.0.71
 
 ## Feature Request
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Claude Code collapses thinking blocks by default, showing only:
 
 You have to press `ctrl+o` every time to see the actual thinking content. This patch makes thinking blocks visible inline automatically.
 
-**Current Version:** Claude Code 2.0.62 (Updated 2025-12-09)
+**Current Version:** Claude Code 2.0.71 (Updated 2025-12-17)
 
 ## Quick Start
 
@@ -108,6 +108,7 @@ function GkQ({streamMode:A}){return null}
 - v2.0.59: Renamed to `DO2`, uses `MP.createElement`, `CRA.useState`
 - v2.0.61: Renamed to `RR2`, uses `rj.createElement`, `vTA.useState`, `P` container
 - v2.0.62: Renamed to `ZT2`, uses `GP.createElement`, `rTA.useState`, `P` container
+- v2.0.71: **DEPRECATED** - Banner function removed; functionality integrated into `mn2` component
 
 ### Patch 2: Force Thinking Visibility (v2.0.46)
 **Before:**
@@ -153,11 +154,12 @@ case"thinking":
 - v2.0.59: Changed to `F89` component, `u3` variable, checks `K` and `G`
 - v2.0.61: Changed to `T69` component, `A3` variable, checks `F` and `G`
 - v2.0.62: Changed to `X59` component, `J3` variable, checks `F` and `G`
+- v2.0.71: Changed to `mn2` component, `b5` variable, checks `H` and `G`
 
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.0.62 installed
+- Claude Code v2.0.71 installed (also works with v2.0.62)
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -265,8 +267,18 @@ Then restart Claude Code.
 
 ## Verification
 
-Check if patches are applied (for v2.0.62):
+Check if patches are applied (for v2.0.71):
 
+```bash
+# Check thinking visibility patch (v2.0.71)
+grep -n 'case"thinking":return b5.createElement(mn2' ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
+
+# Should show: case"thinking":return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
+
+# Note: Patch 1 (banner removal) is deprecated in v2.0.71 - no longer needed
+```
+
+For v2.0.62:
 ```bash
 # Check ZT2 patch
 grep -n "function ZT2" ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
@@ -452,15 +464,18 @@ The minified code patterns change with each Claude Code update:
 | 2.0.59  | `DO2`          | `F89`     | `K,G` check |
 | 2.0.61  | `RR2`          | `T69`     | `F,G` check |
 | 2.0.62  | `ZT2`          | `X59`     | `F,G` check |
+| 2.0.71  | *deprecated*   | `mn2`     | `H,G` check |
 
 When Claude Code updates, function names and component identifiers are regenerated during minification. In some cases (like v2.0.29), the patterns remain unchanged.
+
+**Note on v2.0.71:** The separate banner function was removed. The "Thought for X seconds" message no longer exists - the banner functionality was integrated into the `mn2` thinking component. Only Patch 2 (visibility) is needed for v2.0.71+.
 
 ## Limitations
 
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.0.62
+4. **Version-specific:** Patterns are specific to v2.0.71 (also supports v2.0.62)
 
 ## Feature Request
 
@@ -678,8 +693,8 @@ Developed through analysis of Claude Code's compiled JavaScript. Special thanks 
 
 ---
 
-**Last Updated:** 2025-12-09
-**Claude Code Version:** 2.0.62
+**Last Updated:** 2025-12-17
+**Claude Code Version:** 2.0.71
 **Status:** ✅ Working
 
 ### Quick Reference

--- a/patch-thinking.js
+++ b/patch-thinking.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Thinking Visibility Patcher v2.0.62');
+  console.log('Claude Code Thinking Visibility Patcher v2.0.71');
   console.log('==============================================\n');
   console.log('Usage: node patch-thinking.js [options]\n');
   console.log('Options:');
@@ -27,7 +27,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Thinking Visibility Patcher v2.0.62');
+console.log('Claude Code Thinking Visibility Patcher v2.0.71');
 console.log('==============================================\n');
 
 // Helper function to safely execute shell commands
@@ -176,15 +176,17 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Patch 1: ZT2 Banner Removal (v2.0.62)
-// Note: Changed from RR2 (v2.0.61) to ZT2 (v2.0.62), rTA/GP namespaces, P container
+// Patch 1: Banner Removal (DEPRECATED in v2.0.71)
+// In v2.0.71, the separate banner function (ZT2 in v2.0.62) was removed.
+// The "Thought for X seconds" message no longer exists - banner is now integrated into mn2.
+// This patch is kept for backwards compatibility with older versions.
 const bannerSearchPattern = 'function ZT2({streamMode:A}){let[Q,B]=rTA.useState(null),[G,Z]=rTA.useState(null);if(rTA.useEffect(()=>{if(A==="thinking"&&Q===null)B(Date.now());else if(A!=="thinking"&&Q!==null)Z(Date.now()-Q),B(null)},[A,Q]),A==="thinking")return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thinking…"));if(G!==null)return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thought for ",Math.max(1,Math.round(G/1000)),"s (",GP.createElement($,{dimColor:!0,bold:!0},"ctrl+o")," ","to show thinking)"));return null}';
 const bannerReplacement = 'function ZT2({streamMode:A}){return null}';
 
-// Patch 2: Thinking Visibility (v2.0.62)
-// Note: Changed from T69 (v2.0.61) to X59 (v2.0.62), A3 to J3
-const thinkingSearchPattern = 'case"thinking":if(!F&&!G)return null;return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:F,verbose:G});';
-const thinkingReplacement = 'case"thinking":return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});';
+// Patch 2: Thinking Visibility (v2.0.71)
+// Note: Changed from X59 (v2.0.62) to mn2 (v2.0.71), J3 to b5, F to H
+const thinkingSearchPattern = 'case"thinking":if(!H&&!G)return null;return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:H,verbose:G});';
+const thinkingReplacement = 'case"thinking":return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});';
 
 let patch1Applied = false;
 let patch2Applied = false;
@@ -192,14 +194,14 @@ let patch2Applied = false;
 // Check if patches can be applied
 console.log('Checking patches...\n');
 
-console.log('Patch 1: ZT2 banner removal');
+console.log('Patch 1: Banner removal (deprecated in v2.0.71)');
 if (content.includes(bannerSearchPattern)) {
   patch1Applied = true;
   console.log('  ✅ Pattern found - ready to apply');
 } else if (content.includes(bannerReplacement)) {
   console.log('  ⚠️  Already applied');
 } else {
-  console.log('  ❌ Pattern not found - may need update for newer version');
+  console.log('  ℹ️  Not applicable (banner integrated into thinking component in v2.0.71+)');
 }
 
 console.log('\nPatch 2: Thinking visibility');
@@ -245,7 +247,7 @@ console.log('\nApplying patches...');
 // Apply Patch 1
 if (patch1Applied) {
   content = content.replace(bannerSearchPattern, bannerReplacement);
-  console.log('✅ Patch 1 applied: ZT2 function now returns null');
+  console.log('✅ Patch 1 applied: Banner function now returns null');
 }
 
 // Apply Patch 2

--- a/patch-thinking.js
+++ b/patch-thinking.js
@@ -176,37 +176,20 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Patch 1: Banner Removal (DEPRECATED in v2.0.71)
-// In v2.0.71, the separate banner function (ZT2 in v2.0.62) was removed.
-// The "Thought for X seconds" message no longer exists - banner is now integrated into mn2.
-// This patch is kept for backwards compatibility with older versions.
-const bannerSearchPattern = 'function ZT2({streamMode:A}){let[Q,B]=rTA.useState(null),[G,Z]=rTA.useState(null);if(rTA.useEffect(()=>{if(A==="thinking"&&Q===null)B(Date.now());else if(A!=="thinking"&&Q!==null)Z(Date.now()-Q),B(null)},[A,Q]),A==="thinking")return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thinking…"));if(G!==null)return GP.createElement(P,{marginTop:1},GP.createElement($,{dimColor:!0},"∴ Thought for ",Math.max(1,Math.round(G/1000)),"s (",GP.createElement($,{dimColor:!0,bold:!0},"ctrl+o")," ","to show thinking)"));return null}';
-const bannerReplacement = 'function ZT2({streamMode:A}){return null}';
-
-// Patch 2: Thinking Visibility (v2.0.71)
-// Note: Changed from X59 (v2.0.62) to mn2 (v2.0.71), J3 to b5, F to H
+// Thinking Visibility Patch (v2.0.71)
+// Forces thinking content to always render by setting isTranscriptMode to true
+// Note: In v2.0.71, the separate banner function was removed - only this patch is needed
 const thinkingSearchPattern = 'case"thinking":if(!H&&!G)return null;return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:H,verbose:G});';
 const thinkingReplacement = 'case"thinking":return b5.createElement(mn2,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});';
 
-let patch1Applied = false;
-let patch2Applied = false;
+let patchApplied = false;
 
-// Check if patches can be applied
-console.log('Checking patches...\n');
+// Check if patch can be applied
+console.log('Checking patch...\n');
 
-console.log('Patch 1: Banner removal (deprecated in v2.0.71)');
-if (content.includes(bannerSearchPattern)) {
-  patch1Applied = true;
-  console.log('  ✅ Pattern found - ready to apply');
-} else if (content.includes(bannerReplacement)) {
-  console.log('  ⚠️  Already applied');
-} else {
-  console.log('  ℹ️  Not applicable (banner integrated into thinking component in v2.0.71+)');
-}
-
-console.log('\nPatch 2: Thinking visibility');
+console.log('Thinking visibility patch:');
 if (content.includes(thinkingSearchPattern)) {
-  patch2Applied = true;
+  patchApplied = true;
   console.log('  ✅ Pattern found - ready to apply');
 } else if (content.includes(thinkingReplacement)) {
   console.log('  ⚠️  Already applied');
@@ -217,20 +200,18 @@ if (content.includes(thinkingSearchPattern)) {
 // Dry run mode - just preview
 if (isDryRun) {
   console.log('\n📋 DRY RUN - No changes will be made\n');
-  console.log('Summary:');
-  console.log(`- Patch 1 (banner): ${patch1Applied ? 'WOULD APPLY' : 'SKIP'}`);
-  console.log(`- Patch 2 (visibility): ${patch2Applied ? 'WOULD APPLY' : 'SKIP'}`);
+  console.log(`Thinking visibility patch: ${patchApplied ? 'WOULD APPLY' : 'SKIP'}`);
 
-  if (patch1Applied || patch2Applied) {
-    console.log('\nRun without --dry-run to apply patches.');
+  if (patchApplied) {
+    console.log('\nRun without --dry-run to apply patch.');
   }
   process.exit(0);
 }
 
-// Apply patches
-if (!patch1Applied && !patch2Applied) {
-  console.error('\n❌ No patches to apply');
-  console.error('Patches may already be applied or version may have changed.');
+// Apply patch
+if (!patchApplied) {
+  console.error('\n❌ No patch to apply');
+  console.error('Patch may already be applied or version may have changed.');
   console.error('Run with --dry-run to see details.');
   process.exit(1);
 }
@@ -242,28 +223,16 @@ if (!fs.existsSync(backupPath)) {
   console.log(`✅ Backup created: ${backupPath}`);
 }
 
-console.log('\nApplying patches...');
+console.log('\nApplying patch...');
 
-// Apply Patch 1
-if (patch1Applied) {
-  content = content.replace(bannerSearchPattern, bannerReplacement);
-  console.log('✅ Patch 1 applied: Banner function now returns null');
-}
-
-// Apply Patch 2
-if (patch2Applied) {
-  content = content.replace(thinkingSearchPattern, thinkingReplacement);
-  console.log('✅ Patch 2 applied: thinking content forced visible');
-}
+content = content.replace(thinkingSearchPattern, thinkingReplacement);
+console.log('✅ Thinking visibility patch applied');
 
 // Write file
 console.log('\nWriting patched file...');
 fs.writeFileSync(targetPath, content, 'utf8');
-console.log('✅ File written successfully\n');
+console.log('✅ File written successfully');
 
-console.log('Summary:');
-console.log(`- Patch 1 (banner): ${patch1Applied ? 'APPLIED' : 'SKIPPED'}`);
-console.log(`- Patch 2 (visibility): ${patch2Applied ? 'APPLIED' : 'SKIPPED'}`);
-console.log('\n🎉 Patches applied! Please restart Claude Code for changes to take effect.');
+console.log('\n🎉 Patch applied! Please restart Claude Code for changes to take effect.');
 console.log('\nTo restore original behavior, run: node patch-thinking.js --restore');
 process.exit(0);


### PR DESCRIPTION
## Summary

- Updated patch-thinking.js for Claude Code v2.0.71 compatibility
- **Patch 1 (banner removal)**: Marked as deprecated - the separate banner function no longer exists in v2.0.71; functionality is now integrated into the `mn2` thinking component
- **Patch 2 (thinking visibility)**: Updated patterns (`X59` → `mn2`, `J3` → `b5`, `F` → `H`)
- Updated README.md with version history and documentation

## Key Discovery

In v2.0.71, the "Thought for X seconds" message was removed entirely. The banner functionality is now integrated into the thinking component itself, so only Patch 2 is needed.

## Test Plan

- [x] Installed fresh 2.0.71 in `/tmp/claude-code-test`
- [x] Verified new pattern exists in cli.js
- [x] Applied patch manually to temp installation
- [x] Confirmed replacement pattern works

Co-authored-by: Claude <noreply@anthropic.com>