### PR TITLE
Add tool visibility patch to show file paths instead of collapsed summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Claude Code collapses thinking blocks by default, showing only:
 
 You have to press `ctrl+o` every time to see the actual thinking content. This patch makes thinking blocks visible inline automatically.
 
-**Current Version:** Claude Code 2.1.83 (Updated 2026-03-25)
+**Current Version:** Claude Code 2.1.84 (Updated 2026-03-26)
 
 ## Quick Start
 
@@ -156,12 +156,12 @@ case"thinking":
 - v2.1.31+: Structural change to memo cache block with `q[]` indices
 - v2.1.80: `rE8` component, `S3` namespace, guard `if(!X&&!w)`, two-layer gating
 - v2.1.81: Same patterns as v2.1.80
-- v2.1.83: `uL8` component, `C5` namespace, guard `if(!P&&!w)`, memo `q[31-36]`
+- v2.1.84: `uL8` component, `C5` namespace, guard `if(!P&&!w)`, memo `q[31-36]`
 
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.1.83 installed
+- Claude Code v2.1.84 installed
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -269,7 +269,7 @@ Then restart Claude Code.
 
 ## Verification
 
-Check if patch is applied (for v2.1.83):
+Check if patch is applied (for v2.1.84):
 
 ```bash
 # Check thinking visibility patch (should show if(0) instead of if(!P&&!w))
@@ -462,7 +462,7 @@ When Claude Code updates, function names and component identifiers are regenerat
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.1.83
+4. **Version-specific:** Patterns are specific to v2.1.84
 
 ## Feature Request
 
@@ -680,8 +680,8 @@ Developed through analysis of Claude Code's compiled JavaScript. Special thanks 
 
 ---
 
-**Last Updated:** 2026-03-25
-**Claude Code Version:** 2.1.83
+**Last Updated:** 2026-03-26
+**Claude Code Version:** 2.1.84
 **Status:** ✅ Working
 
 ### Quick Reference

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Claude Code collapses thinking blocks by default, showing only:
 
 You have to press `ctrl+o` every time to see the actual thinking content. This patch makes thinking blocks visible inline automatically.
 
-**Current Version:** Claude Code 2.0.62 (Updated 2025-12-09)
+**Current Version:** Claude Code 2.1.83 (Updated 2026-03-25)
 
 ## Quick Start
 
@@ -153,11 +153,15 @@ case"thinking":
 - v2.0.59: Changed to `F89` component, `u3` variable, checks `K` and `G`
 - v2.0.61: Changed to `T69` component, `A3` variable, checks `F` and `G`
 - v2.0.62: Changed to `X59` component, `J3` variable, checks `F` and `G`
+- v2.1.31+: Structural change to memo cache block with `q[]` indices
+- v2.1.80: `rE8` component, `S3` namespace, guard `if(!X&&!w)`, two-layer gating
+- v2.1.81: Same patterns as v2.1.80
+- v2.1.83: `uL8` component, `C5` namespace, guard `if(!P&&!w)`, memo `q[31-36]`
 
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.0.62 installed
+- Claude Code v2.1.83 installed
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -265,18 +269,13 @@ Then restart Claude Code.
 
 ## Verification
 
-Check if patches are applied (for v2.0.62):
+Check if patch is applied (for v2.1.83):
 
 ```bash
-# Check ZT2 patch
-grep -n "function ZT2" ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
+# Check thinking visibility patch (should show if(0) instead of if(!P&&!w))
+grep -o 'case"thinking":{if(0)' $(npm root -g)/@anthropic-ai/claude-code/cli.js
 
-# Should show: function ZT2({streamMode:A}){return null}
-
-# Check thinking visibility patch
-grep -n 'case"thinking":return J3.createElement(X59' ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js
-
-# Should show: case"thinking":return J3.createElement(X59,{addMargin:Q,param:A,isTranscriptMode:!0,verbose:G});
+# Should output: case"thinking":{if(0)
 ```
 
 ## Troubleshooting
@@ -409,14 +408,17 @@ $(which claude) → resolve symlinks → find cli.js
 - Tracks all attempted paths for detailed error reporting
 - Cross-platform compatible (Windows, macOS, Linux)
 
-### Why Two Patches?
+### How It Works (Two-Layer Gating)
 
-1. **ZT2 Function:** Controls the UI banner shown after thinking completes
-2. **Thinking Renderer:** Controls whether the actual thinking text is displayed
+The `case"thinking"` handler has two independent layers that suppress thinking output:
 
-Both must be patched because they're separate systems:
-- Patching only ZT2 → Blank line appears where thinking should be
-- Patching only the renderer → Banner still shows "ctrl+o to show"
+1. **Layer 1 — Early return guard**: `if(!P&&!w)return null`
+   Returns null when not in transcript mode AND not verbose. The patch changes this to `if(0)return null` (dead code).
+
+2. **Layer 2 — Component prop**: `isTranscriptMode:P`
+   Controls whether the component shows content or collapses it. The patch changes this to `isTranscriptMode:!0`.
+
+Both layers must be fixed or thinking stays invisible. The banner function (ZT2 etc.) was deprecated since v2.0.71.
 
 ### Pattern Evolution Across Versions
 
@@ -460,7 +462,7 @@ When Claude Code updates, function names and component identifiers are regenerat
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.0.62
+4. **Version-specific:** Patterns are specific to v2.1.83
 
 ## Feature Request
 
@@ -678,8 +680,8 @@ Developed through analysis of Claude Code's compiled JavaScript. Special thanks 
 
 ---
 
-**Last Updated:** 2025-12-09
-**Claude Code Version:** 2.0.62
+**Last Updated:** 2026-03-25
+**Claude Code Version:** 2.1.83
 **Status:** ✅ Working
 
 ### Quick Reference

--- a/README.md
+++ b/README.md
@@ -22,18 +22,48 @@ Claude Code collapses thinking blocks by default, showing only:
 
 You have to press `ctrl+o` every time to see the actual thinking content. This patch makes thinking blocks visible inline automatically.
 
-**Current Version:** Claude Code 2.1.84 (Updated 2026-03-26)
+**Current Version:** Claude Code 2.1.110 (Updated 2026-04-16)
+
+## Required Setting (v2.1.64+)
+
+Starting in v2.1.64 (briefly reverted, permanent from v2.1.69), Claude Code sends a
+`redact-thinking-2026-02-12` beta header with every API request. This tells the API
+to **strip thinking text** from the response — thinking blocks still arrive with valid
+cryptographic signatures, but the `thinking` property is an empty string. The
+rendering patch is correct but has nothing to display.
+
+To disable this redaction, you **must** add the following to `~/.claude/settings.json`:
+
+```json
+{
+  "showThinkingSummaries": true
+}
+```
+
+This setting is **not documented** in the [official Claude Code settings docs](https://code.claude.com/docs/en/settings).
+Its internal schema description is *"Show thinking summaries in the transcript view
+(ctrl+o). Default: false."* — but what it actually controls is whether the API request
+includes the `redact-thinking` beta header. Without it, the API never sends thinking
+content to the client, and no client-side patch can make it visible.
+
+**Without this setting, the patch will apply cleanly but you will see no thinking
+content.** The patch script will warn you if the setting is missing.
+
+See also: [anthropics/claude-code#31326](https://github.com/anthropics/claude-code/issues/31326) — upstream bug report confirming thinking content is empty since v2.1.69.
 
 ## Quick Start
 
 ```bash
-# Clone or download this repository
+# 1. Enable thinking content from the API (required since v2.1.64)
+# Add "showThinkingSummaries": true to ~/.claude/settings.json
+
+# 2. Clone or download this repository
 cd claude-code-thinking
 
-# Run the patch script (automatically detects your installation)
+# 3. Run the patch script (automatically detects your installation)
 node patch-thinking.js
 
-# Restart Claude Code
+# 4. Restart Claude Code
 ```
 
 That's it! Thinking blocks now display inline without `ctrl+o`.
@@ -157,11 +187,23 @@ case"thinking":
 - v2.1.80: `rE8` component, `S3` namespace, guard `if(!X&&!w)`, two-layer gating
 - v2.1.81: Same patterns as v2.1.80
 - v2.1.84: `uL8` component, `C5` namespace, guard `if(!P&&!w)`, memo `q[31-36]`
+- v2.1.85: `Xb8` component, `U3` namespace, guard `if(!M&&!A)`, memo `K[31-36]`
+- v2.1.86: `MI8` component, `n3` namespace, guard `if(!M&&!O)`, memo `K[31-36]`
+- v2.1.89: `Wx8` component, `w9` namespace, guard `if(!X&&!O)`, memo `K[34-39]`
+- v2.1.90: `AI8` component, `H9` namespace, guard `if(!X&&!O)`, memo `K[34-39]`
+- v2.1.91: `QI8` component, `j9` namespace, guard `if(!X&&!O)`, memo `K[34-39]`
+- v2.1.92: `Su8` component, `P9` namespace, guard `if(!X&&!A)`, memo `K[34-39]`
+- v2.1.96: `$p8` component, `Z9` namespace, guard `if(!X&&!A)`, memo `K[34-39]`
+- v2.1.97: `Kg8` component, `H9` namespace, guard `if(!X&&!O)`, memo `K[34-39]`
+- v2.1.100: `YU8` component, `J9` namespace, guard `if(!M&&!O)`, memo `K[34-39]`
+- v2.1.101: `kg8` component, `J9` namespace, guard `if(!M&&!O)`, memo `K[34-39]`
+- v2.1.109: `oF8` component, `M9` namespace, guard `if(!M&&!O)`, memo `K[34-39]`
+- v2.1.110: `Wg8` component, `f9` namespace, guard `if(!M&&!O)`, memo `K[34-39]`
 
 ## Installation
 
 ### Prerequisites
-- Claude Code v2.1.84 installed
+- Claude Code v2.1.110 installed
 - Node.js (comes with Claude Code installation)
 
 ### Install Steps
@@ -269,10 +311,10 @@ Then restart Claude Code.
 
 ## Verification
 
-Check if patch is applied (for v2.1.84):
+Check if patch is applied (for v2.1.110):
 
 ```bash
-# Check thinking visibility patch (should show if(0) instead of if(!P&&!w))
+# Check thinking visibility patch (should show if(0) instead of if(!M&&!O))
 grep -o 'case"thinking":{if(0)' $(npm root -g)/@anthropic-ai/claude-code/cli.js
 
 # Should output: case"thinking":{if(0)
@@ -380,7 +422,7 @@ The script automatically works with all Node.js version managers:
 
 ### File Structure
 - **cli.js:** ~3,600+ lines, ~9+ MB (heavily minified)
-- **Version:** Claude Code 2.0.46
+- **Version:** Claude Code 2.1.110
 - **Patches:** Non-invasive, minimal changes
 
 ### Installation Detection System
@@ -412,13 +454,13 @@ $(which claude) → resolve symlinks → find cli.js
 
 The `case"thinking"` handler has two independent layers that suppress thinking output:
 
-1. **Layer 1 — Early return guard**: `if(!P&&!w)return null`
+1. **Layer 1 — Early return guard**: `if(!M&&!O)return null`
    Returns null when not in transcript mode AND not verbose. The patch changes this to `if(0)return null` (dead code).
 
-2. **Layer 2 — Component prop**: `isTranscriptMode:P`
+2. **Layer 2 — Component prop**: `isTranscriptMode:M`
    Controls whether the component shows content or collapses it. The patch changes this to `isTranscriptMode:!0`.
 
-Both layers must be fixed or thinking stays invisible. The banner function (ZT2 etc.) was deprecated since v2.0.71.
+Both layers must be fixed or thinking stays invisible. The banner function (ZT2/vo4 etc.) was deprecated since v2.0.71.
 
 ### Pattern Evolution Across Versions
 
@@ -462,7 +504,7 @@ When Claude Code updates, function names and component identifiers are regenerat
 1. **Breaks on updates:** Must re-run after `claude update`
 2. **Minified code:** Fragile, patterns may change with version updates
 3. **No official config:** This is a workaround until Anthropic adds a native setting
-4. **Version-specific:** Patterns are specific to v2.1.84
+4. **Version-specific:** Patterns are specific to v2.1.110
 
 ## Feature Request
 
@@ -680,8 +722,8 @@ Developed through analysis of Claude Code's compiled JavaScript. Special thanks 
 
 ---
 
-**Last Updated:** 2026-03-26
-**Claude Code Version:** 2.1.84
+**Last Updated:** 2026-04-16
+**Claude Code Version:** 2.1.110
 **Status:** ✅ Working
 
 ### Quick Reference

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.75');
+  console.log('Claude Code Tool Visibility Patcher v2.1.76');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.75');
+console.log('Claude Code Tool Visibility Patcher v2.1.76');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -198,8 +198,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
 // Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
 // Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=v5.createElement(Ed4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
-const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=v5.createElement(Ed4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
+// Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=V3.createElement(fc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=V3.createElement(fc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.77');
+  console.log('Claude Code Tool Visibility Patcher v2.1.78');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.77');
+console.log('Claude Code Tool Visibility Patcher v2.1.78');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -200,8 +200,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
 // Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
 // Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(Wd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(Wd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=T3.createElement(bc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=T3.createElement(bc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.42');
+  console.log('Claude Code Tool Visibility Patcher v2.1.44');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.42');
+console.log('Claude Code Tool Visibility Patcher v2.1.44');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,17 +179,18 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.42)
+// Tool Visibility Patch (v2.1.44)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (yQ4)
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (SQ4)
 // so it always takes the verbose code path showing each tool call with file paths.
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
 //   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
 //   Y=tools, q=lookups, M=isActiveGroup
-const toolVisSearchPattern = 'case"collapsed_read_search":return F5.createElement(yQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
-const toolVisReplacement = 'case"collapsed_read_search":return F5.createElement(yQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+// Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
+const toolVisSearchPattern = 'case"collapsed_read_search":return F5.createElement(SQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
+const toolVisReplacement = 'case"collapsed_read_search":return F5.createElement(SQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.84');
+  console.log('Claude Code Tool Visibility Patcher v2.1.85');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.84');
+console.log('Claude Code Tool Visibility Patcher v2.1.85');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,57 +179,61 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.84)
+// Tool Visibility Patch (v2.1.85)
 // Shows individual tool calls (with file paths/patterns) instead of collapsed
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
-// 4-site patch strategy:
-//   1. Btq verbose branch: force the if-condition to always enter the verbose
-//      branch (which renders individual tool calls via Sx_), while preserving
-//      the original verbose prop value (_) for passthrough.
-//   2. Btq -> Sx_ call: pass verbose:_ so Sx_ knows whether we're in
-//      transcript mode (verbose=true) or normal mode (verbose=false).
-//   3. Sx_ destructuring: accept the new verbose prop as VB.
-//   4. Sx_ renderToolResultMessage: use VB??!0 so results are condensed in
+// 4-site patch strategy (v2.1.85):
+//   Gpz passes verbose:N (where N=w||P) to IKK. IKK checks if(z) to decide
+//   expanded vs collapsed. fpz (inner renderer) hardcodes verbose:!0 in
+//   renderToolResultMessage. The patch forces IKK's verbose branch while
+//   threading the original verbose value to fpz so renderToolResultMessage
+//   gets false (condensed) in normal mode and true (expanded) in transcript.
+//
+//   1. IKK verbose branch: force if(z) → if(!0) so individual tool calls
+//      always render. z retains its original value for passthrough.
+//   2. IKK → fpz call: pass verbose:z so fpz receives the original verbose
+//      value (false=normal, true=transcript).
+//   3. fpz destructuring: accept the new verbose prop as VB.
+//   4. fpz renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
 // Version history for collapsed_read_search renderer:
-// v2.1.81: _t4 -> ay_, verbose=_, context ,[p]),_){let A6=[]
-// v2.1.83: Btq -> mL_, verbose=_, context ,[U]),_){let t=[]
-// v2.1.84: Btq -> Sx_, verbose=_, context ,[F]),_){let s=[]
-//   mL_ -> Sx_ (inner renderer), J6 -> $6 (content var), U -> F (useEffect dep),
-//   t -> s (array var), renderToolResultMessage now uses optional chaining (?.)
+// v2.1.81: _t4 -> ay_, 4-site: force verbose branch, thread verbose through
+// v2.1.83: Btq -> mL_, 4-site: same approach, different var names
+// v2.1.84: Btq -> Sx_, 4-site: same approach, J6->$6, U->F, t->s
+// v2.1.85: Gpz -> IKK -> fpz, 4-site: IKK verbose check if(z), fpz inner
+//   renderer, F unchanged (useEffect dep), z=verbose var, _6=array var
 
-// Patch 1: Force Btq verbose branch (always show individual tool calls)
-// Changes the if-condition from using _ (verbose prop) to !0 (always true)
+// Patch 1: Force IKK verbose branch (always show individual tool calls)
+// Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The _ variable retains its original value for passthrough to Sx_.
-const patch1Search = ',[F]),_){let s=[]';
-const patch1Replace = ',[F]),!0){let s=[]';
+// The z variable retains its original value for passthrough to fpz.
+const patch1Search = ',[F]),z){let _6=[]';
+const patch1Replace = ',[F]),!0){let _6=[]';
 
-// Patch 2: Pass verbose prop through Btq -> Sx_
-// Adds verbose:_ to the Sx_ createElement call so Sx_ receives the original
+// Patch 2: Pass verbose prop through IKK -> fpz
+// Adds verbose:z to the fpz createElement call so fpz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Sx_,{key:$6.id,content:$6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D})';
-const patch2Replace = 'createElement(Sx_,{key:$6.id,content:$6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D,verbose:_})';
+const patch2Search = 'createElement(fpz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:P})';
+const patch2Replace = 'createElement(fpz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:P,verbose:z})';
 
-// Patch 3: Accept verbose prop in Sx_ component
+// Patch 3: Accept verbose prop in fpz component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$}=A';
-const patch3Replace = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$,verbose:VB}=A';
+const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:A,theme:O}=q';
+const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:A,theme:O,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in Sx_ renderToolResultMessage
+// Patch 4: Use verbose prop in fpz renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-// Note: v2.1.84 uses optional chaining (?.) on renderToolResultMessage.
-const patch4Search = 'J.renderToolResultMessage?.(k,[],{verbose:!0,tools:_,theme:$})';
-const patch4Replace = 'J.renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:_,theme:$})';
+const patch4Search = 'J.renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:O})';
+const patch4Replace = 'J.renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,theme:O})';
 
 const patches = [
-  { name: 'Force Btq verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to Sx_', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in Sx_', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in Sx_ results', search: patch4Search, replace: patch4Replace },
+  { name: 'Force IKK verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to fpz', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in fpz', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in fpz results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.62');
+  console.log('Claude Code Tool Visibility Patcher v2.1.63');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.62');
+console.log('Claude Code Tool Visibility Patcher v2.1.63');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,10 +179,10 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.62)
+// Tool Visibility Patch (v2.1.63)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (Ni7)
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer ($r4)
 // so it always takes the verbose code path showing each tool call with file paths.
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
@@ -192,8 +192,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
 // Note: In v2.1.59, g5->c5, Mc4->Ni7
 // Note: In v2.1.62, pattern unchanged from v2.1.59
-const toolVisSearchPattern = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
-const toolVisReplacement = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+// Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
+const toolVisSearchPattern = 'case"collapsed_read_search":return U5.createElement($r4,{message:A,inProgressToolUseIDs:_,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
+const toolVisReplacement = 'case"collapsed_read_search":return U5.createElement($r4,{message:A,inProgressToolUseIDs:_,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.56');
+  console.log('Claude Code Tool Visibility Patcher v2.1.59');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.56');
+console.log('Claude Code Tool Visibility Patcher v2.1.59');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,10 +179,10 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.56)
+// Tool Visibility Patch (v2.1.59)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (Mc4)
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (Ni7)
 // so it always takes the verbose code path showing each tool call with file paths.
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
@@ -190,8 +190,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   Y=tools, q=lookups, M=isActiveGroup
 // Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
 // Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
-const toolVisSearchPattern = 'case"collapsed_read_search":return g5.createElement(Mc4,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
-const toolVisReplacement = 'case"collapsed_read_search":return g5.createElement(Mc4,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+// Note: In v2.1.59, g5->c5, Mc4->Ni7
+const toolVisSearchPattern = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
+const toolVisReplacement = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.76');
+  console.log('Claude Code Tool Visibility Patcher v2.1.77');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.76');
+console.log('Claude Code Tool Visibility Patcher v2.1.77');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -199,8 +199,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
 // Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
 // Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=V3.createElement(fc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=V3.createElement(fc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(Wd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(Wd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.63');
+  console.log('Claude Code Tool Visibility Patcher v2.1.69');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.63');
+console.log('Claude Code Tool Visibility Patcher v2.1.69');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,10 +179,10 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.63)
+// Tool Visibility Patch (v2.1.69)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer ($r4)
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (pt4)
 // so it always takes the verbose code path showing each tool call with file paths.
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
@@ -193,8 +193,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.59, g5->c5, Mc4->Ni7
 // Note: In v2.1.62, pattern unchanged from v2.1.59
 // Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
-const toolVisSearchPattern = 'case"collapsed_read_search":return U5.createElement($r4,{message:A,inProgressToolUseIDs:_,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
-const toolVisReplacement = 'case"collapsed_read_search":return U5.createElement($r4,{message:A,inProgressToolUseIDs:_,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+// Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
+const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[78]!==O||q[79]!==W||q[80]!==Y||q[81]!==K||q[82]!==j||q[83]!==w||q[84]!==$)V=d5.createElement(pt4,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:$,tools:w,lookups:Y,isActiveGroup:W}),q[78]=O,q[79]=W,q[80]=Y,q[81]=K,q[82]=j,q[83]=w,q[84]=$,q[85]=V;else V=q[85];return V}';
+const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[78]!==O||q[79]!==W||q[80]!==Y||q[81]!==K||q[82]!==j||q[83]!==w||q[84]!==$)V=d5.createElement(pt4,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:!0,tools:w,lookups:Y,isActiveGroup:W}),q[78]=O,q[79]=W,q[80]=Y,q[81]=K,q[82]=j,q[83]=w,q[84]=$,q[85]=V;else V=q[85];return V}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.59');
+  console.log('Claude Code Tool Visibility Patcher v2.1.62');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.59');
+console.log('Claude Code Tool Visibility Patcher v2.1.62');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,7 +179,7 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.59)
+// Tool Visibility Patch (v2.1.62)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 // This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (Ni7)
@@ -191,6 +191,7 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
 // Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
 // Note: In v2.1.59, g5->c5, Mc4->Ni7
+// Note: In v2.1.62, pattern unchanged from v2.1.59
 const toolVisSearchPattern = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
 const toolVisReplacement = 'case"collapsed_read_search":return c5.createElement(Ni7,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.44');
+  console.log('Claude Code Tool Visibility Patcher v2.1.56');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.44');
+console.log('Claude Code Tool Visibility Patcher v2.1.56');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,18 +179,19 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.44)
+// Tool Visibility Patch (v2.1.56)
 // Forces collapsed read/search tool groups to always render individual tool calls
 // instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (SQ4)
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (Mc4)
 // so it always takes the verbose code path showing each tool call with file paths.
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
 //   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
 //   Y=tools, q=lookups, M=isActiveGroup
 // Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
-const toolVisSearchPattern = 'case"collapsed_read_search":return F5.createElement(SQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
-const toolVisReplacement = 'case"collapsed_read_search":return F5.createElement(SQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+// Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
+const toolVisSearchPattern = 'case"collapsed_read_search":return g5.createElement(Mc4,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
+const toolVisReplacement = 'case"collapsed_read_search":return g5.createElement(Mc4,{message:A,inProgressToolUseIDs:_,shouldAnimate:H,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.78');
+  console.log('Claude Code Tool Visibility Patcher v2.1.79');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.78');
+console.log('Claude Code Tool Visibility Patcher v2.1.79');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -201,8 +201,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
 // Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=T3.createElement(bc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=T3.createElement(bc4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const isDryRun = args.includes('--dry-run');
+const isRestore = args.includes('--restore');
+const showHelp = args.includes('--help') || args.includes('-h');
+
+// Display help
+if (showHelp) {
+  console.log('Claude Code Tool Visibility Patcher v2.1.42');
+  console.log('=============================================\n');
+  console.log('Usage: node patch-tool-visibility.js [options]\n');
+  console.log('Options:');
+  console.log('  --dry-run    Preview changes without applying them');
+  console.log('  --restore    Restore from backup file');
+  console.log('  --help, -h   Show this help message\n');
+  console.log('Examples:');
+  console.log('  node patch-tool-visibility.js              # Apply patch');
+  console.log('  node patch-tool-visibility.js --dry-run    # Preview changes');
+  console.log('  node patch-tool-visibility.js --restore    # Restore original');
+  console.log('\nThis patch forces Read/Glob/Grep tool calls to always show');
+  console.log('individual file paths and search patterns instead of collapsed');
+  console.log('summaries like "Read 1 file (ctrl+o to expand)".');
+  process.exit(0);
+}
+
+console.log('Claude Code Tool Visibility Patcher v2.1.42');
+console.log('=============================================\n');
+
+// Helper function to safely execute shell commands
+function safeExec(command) {
+  try {
+    return execSync(command, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch (error) {
+    return null;
+  }
+}
+
+// Auto-detect Claude Code installation path
+function getClaudeCodePath() {
+  const homeDir = os.homedir();
+  const attemptedPaths = [];
+
+  // Helper to check and return path if it exists
+  function checkPath(testPath, method) {
+    if (!testPath) return null;
+
+    attemptedPaths.push({ path: testPath, method });
+
+    try {
+      if (fs.existsSync(testPath)) {
+        // Resolve symlinks for global npm installs
+        try {
+          const realPath = fs.realpathSync(testPath);
+          return realPath;
+        } catch (e) {
+          return testPath;
+        }
+      }
+    } catch (error) {
+      // Path check failed, continue
+    }
+    return null;
+  }
+
+  // PRIORITY 1: Local installations (existing behavior - user overrides)
+  const localPaths = [
+    path.join(homeDir, '.claude', 'local', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
+    path.join(homeDir, '.config', 'claude', 'local', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
+  ];
+
+  for (const localPath of localPaths) {
+    const found = checkPath(localPath, 'local installation');
+    if (found) return found;
+  }
+
+  // PRIORITY 2: Global npm installation via 'npm root -g'
+  const npmGlobalRoot = safeExec('npm root -g');
+  if (npmGlobalRoot) {
+    const npmGlobalPath = path.join(npmGlobalRoot, '@anthropic-ai', 'claude-code', 'cli.js');
+    const found = checkPath(npmGlobalPath, 'npm root -g');
+    if (found) return found;
+  }
+
+  // PRIORITY 3: Derive from process.execPath
+  // Global modules are typically in ../lib/node_modules relative to node binary
+  const nodeDir = path.dirname(process.execPath);
+  const derivedGlobalPath = path.join(nodeDir, '..', 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+  const found = checkPath(derivedGlobalPath, 'derived from process.execPath');
+  if (found) return found;
+
+  // PRIORITY 4: Unix systems - try 'which claude' to find binary
+  if (process.platform !== 'win32') {
+    const claudeBinary = safeExec('which claude');
+    if (claudeBinary) {
+      try {
+        // Resolve symlinks
+        const realBinary = fs.realpathSync(claudeBinary);
+        // Navigate from bin/claude to lib/node_modules/@anthropic-ai/claude-code/cli.js
+        const binDir = path.dirname(realBinary);
+        const nodeModulesPath = path.join(binDir, '..', 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+        const foundFromBinary = checkPath(nodeModulesPath, 'which claude');
+        if (foundFromBinary) return foundFromBinary;
+      } catch (e) {
+        // Failed to resolve, continue
+      }
+    }
+  }
+
+  // No installation found, return null and include attempted paths for error reporting
+  getClaudeCodePath.attemptedPaths = attemptedPaths;
+  return null;
+}
+
+const targetPath = getClaudeCodePath();
+
+if (!targetPath) {
+  console.error('❌ Error: Could not find Claude Code installation\n');
+  console.error('Searched using the following methods:\n');
+
+  const attemptedPaths = getClaudeCodePath.attemptedPaths || [];
+
+  if (attemptedPaths.length > 0) {
+    // Group by method for cleaner output
+    const byMethod = {};
+    attemptedPaths.forEach(({ path, method }) => {
+      if (!byMethod[method]) byMethod[method] = [];
+      byMethod[method].push(path);
+    });
+
+    Object.entries(byMethod).forEach(([method, paths]) => {
+      console.error(`  [${method}]`);
+      paths.forEach(p => console.error(`    - ${p}`));
+    });
+  } else {
+    console.error('  - ~/.claude/local/node_modules/@anthropic-ai/claude-code/cli.js');
+    console.error('  - ~/.config/claude/local/node_modules/@anthropic-ai/claude-code/cli.js');
+    console.error('  - Global npm installation (npm root -g)');
+  }
+
+  console.error('\n💡 Troubleshooting:');
+  console.error('  1. Verify Claude Code is installed: claude --version');
+  console.error('  2. For local install: Check ~/.claude/local or ~/.config/claude/local');
+  console.error('  3. For global install: Ensure "npm install -g @anthropic-ai/claude-code" succeeded');
+  console.error('  4. Check that npm is in your PATH if using global install');
+  process.exit(1);
+}
+
+console.log(`Found Claude Code at: ${targetPath}\n`);
+
+const backupPath = targetPath + '.tool-visibility.backup';
+
+// Restore from backup
+if (isRestore) {
+  if (!fs.existsSync(backupPath)) {
+    console.error('❌ Error: Backup file not found at:', backupPath);
+    process.exit(1);
+  }
+
+  console.log('Restoring from backup...');
+  fs.copyFileSync(backupPath, targetPath);
+  console.log('✅ Restored successfully!');
+  console.log('\nPlease restart Claude Code for changes to take effect.');
+  process.exit(0);
+}
+
+// Read file
+console.log('Reading cli.js...');
+if (!fs.existsSync(targetPath)) {
+  console.error('❌ Error: cli.js not found at:', targetPath);
+  process.exit(1);
+}
+
+let content = fs.readFileSync(targetPath, 'utf8');
+
+// Tool Visibility Patch (v2.1.42)
+// Forces collapsed read/search tool groups to always render individual tool calls
+// instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (yQ4)
+// so it always takes the verbose code path showing each tool call with file paths.
+// Note: In v2.1.42, the relevant variables in PyY are:
+//   F5=createElement namespace, yQ4=collapsed renderer component,
+//   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
+//   Y=tools, q=lookups, M=isActiveGroup
+const toolVisSearchPattern = 'case"collapsed_read_search":return F5.createElement(yQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:w,tools:Y,lookups:q,isActiveGroup:M})';
+const toolVisReplacement = 'case"collapsed_read_search":return F5.createElement(yQ4,{message:A,inProgressToolUseIDs:H,shouldAnimate:O,verbose:!0,tools:Y,lookups:q,isActiveGroup:M})';
+
+let patchApplied = false;
+
+// Check if patch can be applied
+console.log('Checking patch...\n');
+
+console.log('Tool visibility patch:');
+if (content.includes(toolVisSearchPattern)) {
+  patchApplied = true;
+  console.log('  ✅ Pattern found - ready to apply');
+} else if (content.includes(toolVisReplacement)) {
+  console.log('  ⚠️  Already applied');
+} else {
+  console.log('  ❌ Pattern not found - may need update for newer version');
+}
+
+// Dry run mode - just preview
+if (isDryRun) {
+  console.log('\n📋 DRY RUN - No changes will be made\n');
+  console.log(`Tool visibility patch: ${patchApplied ? 'WOULD APPLY' : 'SKIP'}`);
+
+  if (patchApplied) {
+    console.log('\nRun without --dry-run to apply patch.');
+  }
+  process.exit(0);
+}
+
+// Apply patch
+if (!patchApplied) {
+  console.error('\n❌ No patch to apply');
+  console.error('Patch may already be applied or version may have changed.');
+  console.error('Run with --dry-run to see details.');
+  process.exit(1);
+}
+
+// Create backup if it doesn't exist
+if (!fs.existsSync(backupPath)) {
+  console.log('\nCreating backup...');
+  fs.copyFileSync(targetPath, backupPath);
+  console.log(`✅ Backup created: ${backupPath}`);
+}
+
+console.log('\nApplying patch...');
+
+content = content.replace(toolVisSearchPattern, toolVisReplacement);
+console.log('✅ Tool visibility patch applied');
+
+// Write file
+console.log('\nWriting patched file...');
+fs.writeFileSync(targetPath, content, 'utf8');
+console.log('✅ File written successfully');
+
+console.log('\n🎉 Patch applied! Please restart Claude Code for changes to take effect.');
+console.log('\nTo restore original behavior, run: node patch-tool-visibility.js --restore');
+process.exit(0);

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.72');
+  console.log('Claude Code Tool Visibility Patcher v2.1.74');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.72');
+console.log('Claude Code Tool Visibility Patcher v2.1.74');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -196,8 +196,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
 // Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
 // Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=M5.createElement(FQ4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=M5.createElement(FQ4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=G5.createElement(Nd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
+const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=G5.createElement(Nd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.83');
+  console.log('Claude Code Tool Visibility Patcher v2.1.84');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.83');
+console.log('Claude Code Tool Visibility Patcher v2.1.84');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,55 +179,57 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.83)
+// Tool Visibility Patch (v2.1.84)
 // Shows individual tool calls (with file paths/patterns) instead of collapsed
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
 // 4-site patch strategy:
 //   1. Btq verbose branch: force the if-condition to always enter the verbose
-//      branch (which renders individual tool calls via mL_), while preserving
+//      branch (which renders individual tool calls via Sx_), while preserving
 //      the original verbose prop value (_) for passthrough.
-//   2. Btq -> mL_ call: pass verbose:_ so mL_ knows whether we're in
+//   2. Btq -> Sx_ call: pass verbose:_ so Sx_ knows whether we're in
 //      transcript mode (verbose=true) or normal mode (verbose=false).
-//   3. mL_ destructuring: accept the new verbose prop as VB.
-//   4. mL_ renderToolResultMessage: use VB??!0 so results are condensed in
+//   3. Sx_ destructuring: accept the new verbose prop as VB.
+//   4. Sx_ renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
 // Version history for collapsed_read_search renderer:
 // v2.1.81: _t4 -> ay_, verbose=_, context ,[p]),_){let A6=[]
 // v2.1.83: Btq -> mL_, verbose=_, context ,[U]),_){let t=[]
-//   ay_ -> mL_ (inner renderer), M6 -> J6 (content var), Y<->z (tools/lookups swapped),
-//   P -> D (theme in main), O -> $ (theme in inner), p -> U (useEffect dep), A6 -> t (array var)
+// v2.1.84: Btq -> Sx_, verbose=_, context ,[F]),_){let s=[]
+//   mL_ -> Sx_ (inner renderer), J6 -> $6 (content var), U -> F (useEffect dep),
+//   t -> s (array var), renderToolResultMessage now uses optional chaining (?.)
 
 // Patch 1: Force Btq verbose branch (always show individual tool calls)
 // Changes the if-condition from using _ (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The _ variable retains its original value for passthrough to mL_.
-const patch1Search = ',[U]),_){let t=[]';
-const patch1Replace = ',[U]),!0){let t=[]';
+// The _ variable retains its original value for passthrough to Sx_.
+const patch1Search = ',[F]),_){let s=[]';
+const patch1Replace = ',[F]),!0){let s=[]';
 
-// Patch 2: Pass verbose prop through Btq -> mL_
-// Adds verbose:_ to the mL_ createElement call so mL_ receives the original
+// Patch 2: Pass verbose prop through Btq -> Sx_
+// Adds verbose:_ to the Sx_ createElement call so Sx_ receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(mL_,{key:J6.id,content:J6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D})';
-const patch2Replace = 'createElement(mL_,{key:J6.id,content:J6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D,verbose:_})';
+const patch2Search = 'createElement(Sx_,{key:$6.id,content:$6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D})';
+const patch2Replace = 'createElement(Sx_,{key:$6.id,content:$6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D,verbose:_})';
 
-// Patch 3: Accept verbose prop in mL_ component
+// Patch 3: Accept verbose prop in Sx_ component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$}=A';
 const patch3Replace = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$,verbose:VB}=A';
 
-// Patch 4: Use verbose prop in mL_ renderToolResultMessage
+// Patch 4: Use verbose prop in Sx_ renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'J.renderToolResultMessage(k,[],{verbose:!0,tools:_,theme:$})';
-const patch4Replace = 'J.renderToolResultMessage(k,[],{verbose:VB??!0,tools:_,theme:$})';
+// Note: v2.1.84 uses optional chaining (?.) on renderToolResultMessage.
+const patch4Search = 'J.renderToolResultMessage?.(k,[],{verbose:!0,tools:_,theme:$})';
+const patch4Replace = 'J.renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:_,theme:$})';
 
 const patches = [
   { name: 'Force Btq verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to mL_', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in mL_', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in mL_ results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to Sx_', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in Sx_', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in Sx_ results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.71');
+  console.log('Claude Code Tool Visibility Patcher v2.1.72');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.71');
+console.log('Claude Code Tool Visibility Patcher v2.1.72');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -195,8 +195,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
 // Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
 // Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[81]!==O||q[82]!==W||q[83]!==Y||q[84]!==K||q[85]!==j||q[86]!==w||q[87]!==$)N=o5.createElement(O7q,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:$,tools:w,lookups:Y,isActiveGroup:W}),q[81]=O,q[82]=W,q[83]=Y,q[84]=K,q[85]=j,q[86]=w,q[87]=$,q[88]=N;else N=q[88];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[81]!==O||q[82]!==W||q[83]!==Y||q[84]!==K||q[85]!==j||q[86]!==w||q[87]!==$)N=o5.createElement(O7q,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:!0,tools:w,lookups:Y,isActiveGroup:W}),q[81]=O,q[82]=W,q[83]=Y,q[84]=K,q[85]=j,q[86]=w,q[87]=$,q[88]=N;else N=q[88];return N}';
+// Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=M5.createElement(FQ4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=M5.createElement(FQ4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.69');
+  console.log('Claude Code Tool Visibility Patcher v2.1.71');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.69');
+console.log('Claude Code Tool Visibility Patcher v2.1.71');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -194,8 +194,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.62, pattern unchanged from v2.1.59
 // Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
 // Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
-const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[78]!==O||q[79]!==W||q[80]!==Y||q[81]!==K||q[82]!==j||q[83]!==w||q[84]!==$)V=d5.createElement(pt4,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:$,tools:w,lookups:Y,isActiveGroup:W}),q[78]=O,q[79]=W,q[80]=Y,q[81]=K,q[82]=j,q[83]=w,q[84]=$,q[85]=V;else V=q[85];return V}';
-const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[78]!==O||q[79]!==W||q[80]!==Y||q[81]!==K||q[82]!==j||q[83]!==w||q[84]!==$)V=d5.createElement(pt4,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:!0,tools:w,lookups:Y,isActiveGroup:W}),q[78]=O,q[79]=W,q[80]=Y,q[81]=K,q[82]=j,q[83]=w,q[84]=$,q[85]=V;else V=q[85];return V}';
+// Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[81]!==O||q[82]!==W||q[83]!==Y||q[84]!==K||q[85]!==j||q[86]!==w||q[87]!==$)N=o5.createElement(O7q,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:$,tools:w,lookups:Y,isActiveGroup:W}),q[81]=O,q[82]=W,q[83]=Y,q[84]=K,q[85]=j,q[86]=w,q[87]=$,q[88]=N;else N=q[88];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[81]!==O||q[82]!==W||q[83]!==Y||q[84]!==K||q[85]!==j||q[86]!==w||q[87]!==$)N=o5.createElement(O7q,{message:K,inProgressToolUseIDs:O,shouldAnimate:j,verbose:!0,tools:w,lookups:Y,isActiveGroup:W}),q[81]=O,q[82]=W,q[83]=Y,q[84]=K,q[85]=j,q[86]=w,q[87]=$,q[88]=N;else N=q[88];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.81');
+  console.log('Claude Code Tool Visibility Patcher v2.1.83');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.81');
+console.log('Claude Code Tool Visibility Patcher v2.1.83');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,71 +179,55 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.81)
+// Tool Visibility Patch (v2.1.83)
 // Shows individual tool calls (with file paths/patterns) instead of collapsed
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
 // 4-site patch strategy:
-//   1. _t4 verbose branch: force the if-condition to always enter the verbose
-//      branch (which renders individual tool calls via ay_), while preserving
+//   1. Btq verbose branch: force the if-condition to always enter the verbose
+//      branch (which renders individual tool calls via mL_), while preserving
 //      the original verbose prop value (_) for passthrough.
-//   2. _t4 -> ay_ call: pass verbose:_ so ay_ knows whether we're in
+//   2. Btq -> mL_ call: pass verbose:_ so mL_ knows whether we're in
 //      transcript mode (verbose=true) or normal mode (verbose=false).
-//   3. ay_ destructuring: accept the new verbose prop as VB.
-//   4. ay_ renderToolResultMessage: use VB??!0 so results are condensed in
+//   3. mL_ destructuring: accept the new verbose prop as VB.
+//   4. mL_ renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
-// Version history for collapsed_read_search case in oy_:
-// Note: In v2.1.42, the relevant variables in PyY are:
-//   F5=createElement namespace, yQ4=collapsed renderer component,
-//   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
-//   Y=tools, q=lookups, M=isActiveGroup
-// Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
-// Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
-// Note: In v2.1.59, g5->c5, Mc4->Ni7
-// Note: In v2.1.62, pattern unchanged from v2.1.59
-// Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
-// Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
-// Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
-// Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
-// Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
-// Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
-// Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
-// Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.80, E3->R3, _a4->co4, N->k, tool list prop _->z
-// Note: In v2.1.81, R3->S3, co4->_t4, lookups var Y->_
+// Version history for collapsed_read_search renderer:
+// v2.1.81: _t4 -> ay_, verbose=_, context ,[p]),_){let A6=[]
+// v2.1.83: Btq -> mL_, verbose=_, context ,[U]),_){let t=[]
+//   ay_ -> mL_ (inner renderer), M6 -> J6 (content var), Y<->z (tools/lookups swapped),
+//   P -> D (theme in main), O -> $ (theme in inner), p -> U (useEffect dep), A6 -> t (array var)
 
-// Patch 1: Force _t4 verbose branch (always show individual tool calls)
+// Patch 1: Force Btq verbose branch (always show individual tool calls)
 // Changes the if-condition from using _ (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The _ variable retains its original value for passthrough to ay_.
-const patch1Search = ',[p]),_){let A6=[]';
-const patch1Replace = ',[p]),!0){let A6=[]';
+// The _ variable retains its original value for passthrough to mL_.
+const patch1Search = ',[U]),_){let t=[]';
+const patch1Replace = ',[U]),!0){let t=[]';
 
-// Patch 2: Pass verbose prop through _t4 -> ay_
-// Adds verbose:_ to the ay_ createElement call so ay_ receives the original
+// Patch 2: Pass verbose prop through Btq -> mL_
+// Adds verbose:_ to the mL_ createElement call so mL_ receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(ay_,{key:M6.id,content:M6,tools:Y,lookups:z,inProgressToolUseIDs:q,shouldAnimate:K,theme:P})';
-const patch2Replace = 'createElement(ay_,{key:M6.id,content:M6,tools:Y,lookups:z,inProgressToolUseIDs:q,shouldAnimate:K,theme:P,verbose:_})';
+const patch2Search = 'createElement(mL_,{key:J6.id,content:J6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D})';
+const patch2Replace = 'createElement(mL_,{key:J6.id,content:J6,tools:z,lookups:Y,inProgressToolUseIDs:q,shouldAnimate:K,theme:D,verbose:_})';
 
-// Patch 3: Accept verbose prop in ay_ component
+// Patch 3: Accept verbose prop in mL_ component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:K,tools:_,lookups:Y,inProgressToolUseIDs:z,shouldAnimate:w,theme:O}=A';
-const patch3Replace = '{content:K,tools:_,lookups:Y,inProgressToolUseIDs:z,shouldAnimate:w,theme:O,verbose:VB}=A';
+const patch3Search = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$}=A';
+const patch3Replace = '{content:K,tools:_,lookups:z,inProgressToolUseIDs:Y,shouldAnimate:w,theme:$,verbose:VB}=A';
 
-// Patch 4: Use verbose prop in ay_ renderToolResultMessage
+// Patch 4: Use verbose prop in mL_ renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'J.renderToolResultMessage(k,[],{verbose:!0,tools:_,theme:O})';
-const patch4Replace = 'J.renderToolResultMessage(k,[],{verbose:VB??!0,tools:_,theme:O})';
+const patch4Search = 'J.renderToolResultMessage(k,[],{verbose:!0,tools:_,theme:$})';
+const patch4Replace = 'J.renderToolResultMessage(k,[],{verbose:VB??!0,tools:_,theme:$})';
 
 const patches = [
-  { name: 'Force _t4 verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to ay_', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in ay_', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in ay_ results', search: patch4Search, replace: patch4Replace },
+  { name: 'Force Btq verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to mL_', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in mL_', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in mL_ results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.80');
+  console.log('Claude Code Tool Visibility Patcher v2.1.81');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.80');
+console.log('Claude Code Tool Visibility Patcher v2.1.81');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -203,8 +203,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.80, E3->R3, _a4->co4, N->k, tool list prop _->z
-const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
-const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
+// Note: In v2.1.81, R3->S3, co4->_t4, lookups var Y->_
+const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==_||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=S3.createElement(_t4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:_,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=_,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
+const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==_||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=S3.createElement(_t4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:_,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=_,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -202,9 +202,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.80, collapsed renderer changed to `_a4`, component namespace `E3`, verbose prop `O`, tool list prop `_`
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Note: In v2.1.80, E3->R3, _a4->co4, N->k, tool list prop _->z
+const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
+const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -179,11 +179,21 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.80)
-// Forces collapsed read/search tool groups to always render individual tool calls
-// instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (co4)
-// so it always takes the verbose code path showing each tool call with file paths.
+// Tool Visibility Patch (v2.1.81)
+// Shows individual tool calls (with file paths/patterns) instead of collapsed
+// summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
+//
+// 4-site patch strategy:
+//   1. _t4 verbose branch: force the if-condition to always enter the verbose
+//      branch (which renders individual tool calls via ay_), while preserving
+//      the original verbose prop value (_) for passthrough.
+//   2. _t4 -> ay_ call: pass verbose:_ so ay_ knows whether we're in
+//      transcript mode (verbose=true) or normal mode (verbose=false).
+//   3. ay_ destructuring: accept the new verbose prop as VB.
+//   4. ay_ renderToolResultMessage: use VB??!0 so results are condensed in
+//      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
+//
+// Version history for collapsed_read_search case in oy_:
 // Note: In v2.1.42, the relevant variables in PyY are:
 //   F5=createElement namespace, yQ4=collapsed renderer component,
 //   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
@@ -204,41 +214,85 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
 // Note: In v2.1.80, E3->R3, _a4->co4, N->k, tool list prop _->z
 // Note: In v2.1.81, R3->S3, co4->_t4, lookups var Y->_
-const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==_||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=S3.createElement(_t4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:_,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=_,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
-const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==_||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=S3.createElement(_t4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:_,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=_,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
 
-let patchApplied = false;
+// Patch 1: Force _t4 verbose branch (always show individual tool calls)
+// Changes the if-condition from using _ (verbose prop) to !0 (always true)
+// so the verbose branch is always entered regardless of mode.
+// The _ variable retains its original value for passthrough to ay_.
+const patch1Search = ',[p]),_){let A6=[]';
+const patch1Replace = ',[p]),!0){let A6=[]';
 
-// Check if patch can be applied
-console.log('Checking patch...\n');
+// Patch 2: Pass verbose prop through _t4 -> ay_
+// Adds verbose:_ to the ay_ createElement call so ay_ receives the original
+// verbose value (false in normal mode, true in transcript mode).
+const patch2Search = 'createElement(ay_,{key:M6.id,content:M6,tools:Y,lookups:z,inProgressToolUseIDs:q,shouldAnimate:K,theme:P})';
+const patch2Replace = 'createElement(ay_,{key:M6.id,content:M6,tools:Y,lookups:z,inProgressToolUseIDs:q,shouldAnimate:K,theme:P,verbose:_})';
 
-console.log('Tool visibility patch:');
-if (content.includes(toolVisSearchPattern)) {
-  patchApplied = true;
-  console.log('  ✅ Pattern found - ready to apply');
-} else if (content.includes(toolVisReplacement)) {
-  console.log('  ⚠️  Already applied');
-} else {
-  console.log('  ❌ Pattern not found - may need update for newer version');
+// Patch 3: Accept verbose prop in ay_ component
+// Adds verbose:VB to the destructuring so it's available in the function body.
+const patch3Search = '{content:K,tools:_,lookups:Y,inProgressToolUseIDs:z,shouldAnimate:w,theme:O}=A';
+const patch3Replace = '{content:K,tools:_,lookups:Y,inProgressToolUseIDs:z,shouldAnimate:w,theme:O,verbose:VB}=A';
+
+// Patch 4: Use verbose prop in ay_ renderToolResultMessage
+// Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
+// VB is false (normal mode) but fully expanded when VB is true (transcript).
+const patch4Search = 'J.renderToolResultMessage(k,[],{verbose:!0,tools:_,theme:O})';
+const patch4Replace = 'J.renderToolResultMessage(k,[],{verbose:VB??!0,tools:_,theme:O})';
+
+const patches = [
+  { name: 'Force _t4 verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to ay_', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in ay_', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in ay_ results', search: patch4Search, replace: patch4Replace },
+];
+
+// Check which patches can be applied
+console.log('Checking patches...\n');
+
+let anyToApply = false;
+let allApplied = true;
+
+for (let i = 0; i < patches.length; i++) {
+  const p = patches[i];
+  console.log(`Patch ${i + 1}: ${p.name}`);
+  if (content.includes(p.search)) {
+    p.ready = true;
+    anyToApply = true;
+    allApplied = false;
+    console.log('  ✅ Pattern found - ready to apply');
+  } else if (content.includes(p.replace)) {
+    p.ready = false;
+    console.log('  ⚠️  Already applied');
+  } else {
+    p.ready = false;
+    allApplied = false;
+    console.log('  ❌ Pattern not found - may need update for newer version');
+  }
 }
 
 // Dry run mode - just preview
 if (isDryRun) {
   console.log('\n📋 DRY RUN - No changes will be made\n');
-  console.log(`Tool visibility patch: ${patchApplied ? 'WOULD APPLY' : 'SKIP'}`);
-
-  if (patchApplied) {
-    console.log('\nRun without --dry-run to apply patch.');
+  for (let i = 0; i < patches.length; i++) {
+    const p = patches[i];
+    console.log(`Patch ${i + 1} (${p.name}): ${p.ready ? 'WOULD APPLY' : 'SKIP'}`);
+  }
+  if (anyToApply) {
+    console.log('\nRun without --dry-run to apply patches.');
   }
   process.exit(0);
 }
 
-// Apply patch
-if (!patchApplied) {
-  console.error('\n❌ No patch to apply');
-  console.error('Patch may already be applied or version may have changed.');
-  console.error('Run with --dry-run to see details.');
-  process.exit(1);
+// Apply patches
+if (!anyToApply) {
+  if (allApplied) {
+    console.log('\n⚠️  All patches already applied.');
+  } else {
+    console.error('\n❌ No patches to apply');
+    console.error('Patches may already be applied or version may have changed.');
+    console.error('Run with --dry-run to see details.');
+  }
+  process.exit(allApplied ? 0 : 1);
 }
 
 // Create backup if it doesn't exist
@@ -248,10 +302,15 @@ if (!fs.existsSync(backupPath)) {
   console.log(`✅ Backup created: ${backupPath}`);
 }
 
-console.log('\nApplying patch...');
+console.log('\nApplying patches...');
 
-content = content.replace(toolVisSearchPattern, toolVisReplacement);
-console.log('✅ Tool visibility patch applied');
+for (let i = 0; i < patches.length; i++) {
+  const p = patches[i];
+  if (p.ready) {
+    content = content.replace(p.search, p.replace);
+    console.log(`✅ Patch ${i + 1} applied: ${p.name}`);
+  }
+}
 
 // Write file
 console.log('\nWriting patched file...');

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -180,10 +180,31 @@ if (!fs.existsSync(targetPath)) {
 let content = fs.readFileSync(targetPath, 'utf8');
 
 // Tool Visibility Patch (v2.1.80)
-// In v2.1.80 the collapsed renderer is `co4`, with createElement namespace `R3`, verbose prop `O`, and tool list prop `z`.
-// The patch forces `verbose:!0` so read/search groups render individual tool calls instead of collapsed summaries.
-const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
-const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
+// Forces collapsed read/search tool groups to always render individual tool calls
+// instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
+// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (co4)
+// so it always takes the verbose code path showing each tool call with file paths.
+// Note: In v2.1.42, the relevant variables in PyY are:
+//   F5=createElement namespace, yQ4=collapsed renderer component,
+//   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
+//   Y=tools, q=lookups, M=isActiveGroup
+// Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
+// Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
+// Note: In v2.1.59, g5->c5, Mc4->Ni7
+// Note: In v2.1.62, pattern unchanged from v2.1.59
+// Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
+// Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
+// Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
+// Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
+// Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
+// Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
+// Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
+// Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
+// Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
+// Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
+// Note: In v2.1.80, collapsed renderer changed to `_a4`, component namespace `E3`, verbose prop `O`, tool list prop `_`
+const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.79');
+  console.log('Claude Code Tool Visibility Patcher v2.1.80');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.79');
+console.log('Claude Code Tool Visibility Patcher v2.1.80');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,31 +179,11 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.69)
-// Forces collapsed read/search tool groups to always render individual tool calls
-// instead of summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
-// This is achieved by forcing verbose:!0 in the collapsed_read_search renderer (pt4)
-// so it always takes the verbose code path showing each tool call with file paths.
-// Note: In v2.1.42, the relevant variables in PyY are:
-//   F5=createElement namespace, yQ4=collapsed renderer component,
-//   A=message, H=inProgressToolUseIDs, O=shouldAnimate, w=verbose,
-//   Y=tools, q=lookups, M=isActiveGroup
-// Note: In v2.1.44, collapsed renderer changed: yQ4->SQ4
-// Note: In v2.1.56, F5->g5, SQ4->Mc4, H->_ (inProgressToolUseIDs), O->H (shouldAnimate)
-// Note: In v2.1.59, g5->c5, Mc4->Ni7
-// Note: In v2.1.62, pattern unchanged from v2.1.59
-// Note: In v2.1.63, c5->U5, Ni7->$r4, H->O (shouldAnimate)
-// Note: In v2.1.69, structural change to memo cache block, U5->d5, $r4->pt4, A->K (message), _->O (ids), O->j (anim), w->$ (verbose), Y->w (tools), q->Y (lookups), M->W (group)
-// Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
-// Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
-// Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
-// Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
-// Note: In v2.1.76, v5->V3, Ed4->fc4, V->N (memo temp var), prop vars and indices unchanged
-// Note: In v2.1.77, V3->E3, fc4->Wd4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.78, E3->T3, Wd4->bc4, N unchanged, prop vars and indices unchanged
-// Note: In v2.1.79, T3->E3, bc4->_a4, N unchanged, prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
-const toolVisReplacement = 'case"collapsed_read_search":{let N;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)N=E3.createElement(_a4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=N;else N=q[89];return N}';
+// Tool Visibility Patch (v2.1.80)
+// In v2.1.80 the collapsed renderer is `co4`, with createElement namespace `R3`, verbose prop `O`, and tool list prop `z`.
+// The patch forces `verbose:!0` so read/search groups render individual tool calls instead of collapsed summaries.
+const toolVisSearchPattern = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
+const toolVisReplacement = 'case"collapsed_read_search":{let k;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==z||q[88]!==O)k=R3.createElement(co4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:z,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=z,q[88]=O,q[89]=k;else k=q[89];return k}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.74');
+  console.log('Claude Code Tool Visibility Patcher v2.1.75');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.74');
+console.log('Claude Code Tool Visibility Patcher v2.1.75');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -197,8 +197,9 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // Note: In v2.1.71, d5->o5, pt4->O7q, V->N, memo indices shifted q[78-85]->q[81-88]
 // Note: In v2.1.72, o5->M5, O7q->FQ4, O->$ (ids), $->O (verbose), w->_ (tools), memo indices shifted q[81-88]->q[82-89]
 // Note: In v2.1.74, M5->G5, FQ4->Nd4, N->V (memo temp var), prop vars and indices unchanged
-const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=G5.createElement(Nd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
-const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=G5.createElement(Nd4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
+// Note: In v2.1.75, G5->v5, Nd4->Ed4, prop vars and indices unchanged
+const toolVisSearchPattern = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=v5.createElement(Ed4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:O,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
+const toolVisReplacement = 'case"collapsed_read_search":{let V;if(q[82]!==$||q[83]!==W||q[84]!==Y||q[85]!==K||q[86]!==j||q[87]!==_||q[88]!==O)V=v5.createElement(Ed4,{message:K,inProgressToolUseIDs:$,shouldAnimate:j,verbose:!0,tools:_,lookups:Y,isActiveGroup:W}),q[82]=$,q[83]=W,q[84]=Y,q[85]=K,q[86]=j,q[87]=_,q[88]=O,q[89]=V;else V=q[89];return V}';
 
 let patchApplied = false;
 

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.85');
+  console.log('Claude Code Tool Visibility Patcher v2.1.86');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.85');
+console.log('Claude Code Tool Visibility Patcher v2.1.86');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,23 +179,23 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.85)
+// Tool Visibility Patch (v2.1.86)
 // Shows individual tool calls (with file paths/patterns) instead of collapsed
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
-// 4-site patch strategy (v2.1.85):
-//   Gpz passes verbose:N (where N=w||P) to IKK. IKK checks if(z) to decide
-//   expanded vs collapsed. fpz (inner renderer) hardcodes verbose:!0 in
-//   renderToolResultMessage. The patch forces IKK's verbose branch while
-//   threading the original verbose value to fpz so renderToolResultMessage
+// 4-site patch strategy (v2.1.86):
+//   iiY passes verbose:N (where N=w||P) to R_K. R_K checks if(Y) to decide
+//   expanded vs collapsed. hiY (inner renderer) hardcodes verbose:!0 in
+//   renderToolResultMessage. The patch forces R_K's verbose branch while
+//   threading the original verbose value to hiY so renderToolResultMessage
 //   gets false (condensed) in normal mode and true (expanded) in transcript.
 //
-//   1. IKK verbose branch: force if(z) → if(!0) so individual tool calls
-//      always render. z retains its original value for passthrough.
-//   2. IKK → fpz call: pass verbose:z so fpz receives the original verbose
+//   1. R_K verbose branch: force if(Y) → if(!0) so individual tool calls
+//      always render. Y retains its original value for passthrough.
+//   2. R_K → hiY call: pass verbose:Y so hiY receives the original verbose
 //      value (false=normal, true=transcript).
-//   3. fpz destructuring: accept the new verbose prop as VB.
-//   4. fpz renderToolResultMessage: use VB??!0 so results are condensed in
+//   3. hiY destructuring: accept the new verbose prop as VB.
+//   4. hiY renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
 // Version history for collapsed_read_search renderer:
@@ -204,36 +204,38 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // v2.1.84: Btq -> Sx_, 4-site: same approach, J6->$6, U->F, t->s
 // v2.1.85: Gpz -> IKK -> fpz, 4-site: IKK verbose check if(z), fpz inner
 //   renderer, F unchanged (useEffect dep), z=verbose var, _6=array var
+// v2.1.86: iiY -> R_K -> hiY, 4-site: R_K verbose check if(Y), hiY inner
+//   renderer, g=useEffect dep, Y=verbose var, X6=array var
 
-// Patch 1: Force IKK verbose branch (always show individual tool calls)
-// Changes the if-condition from using z (verbose prop) to !0 (always true)
+// Patch 1: Force R_K verbose branch (always show individual tool calls)
+// Changes the if-condition from using Y (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to fpz.
-const patch1Search = ',[F]),z){let _6=[]';
-const patch1Replace = ',[F]),!0){let _6=[]';
+// The Y variable retains its original value for passthrough to hiY.
+const patch1Search = ',[g]),Y){let X6=[]';
+const patch1Replace = ',[g]),!0){let X6=[]';
 
-// Patch 2: Pass verbose prop through IKK -> fpz
-// Adds verbose:z to the fpz createElement call so fpz receives the original
+// Patch 2: Pass verbose prop through R_K -> hiY
+// Adds verbose:Y to the hiY createElement call so hiY receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(fpz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:P})';
-const patch2Replace = 'createElement(fpz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:P,verbose:z})';
+const patch2Search = 'createElement(hiY,{key:V6.id,content:V6,tools:z,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:P})';
+const patch2Replace = 'createElement(hiY,{key:V6.id,content:V6,tools:z,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:P,verbose:Y})';
 
-// Patch 3: Accept verbose prop in fpz component
+// Patch 3: Accept verbose prop in hiY component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:A,theme:O}=q';
-const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:A,theme:O,verbose:VB}=q';
+const patch3Search = '{content:_,tools:Y,lookups:z,inProgressToolUseIDs:A,shouldAnimate:O,theme:$}=q';
+const patch3Replace = '{content:_,tools:Y,lookups:z,inProgressToolUseIDs:A,shouldAnimate:O,theme:$,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in fpz renderToolResultMessage
+// Patch 4: Use verbose prop in hiY renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'J.renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:O})';
-const patch4Replace = 'J.renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,theme:O})';
+const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:Y,theme:$})';
+const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:Y,theme:$})';
 
 const patches = [
-  { name: 'Force IKK verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to fpz', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in fpz', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in fpz results', search: patch4Search, replace: patch4Replace },
+  { name: 'Force R_K verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to hiY', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in hiY', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in hiY results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.89');
+  console.log('Claude Code Tool Visibility Patcher v2.1.90');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.89');
+console.log('Claude Code Tool Visibility Patcher v2.1.90');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -208,36 +208,38 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, g=useEffect dep, Y=verbose var, X6=array var
 // v2.1.89: nKK -> OQz, 4-site: nKK verbose check if(z), OQz inner
 //   renderer, z=verbose var, P6=array var
+// v2.1.90: nKK -> Tdz, 4-site: verbose check if(z), Tdz inner
+//   renderer, z=verbose var, H6=array var, J6=key var
 
-// Patch 1: Force nKK verbose branch (always show individual tool calls)
+// Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to OQz.
-const patch1Search = '$Qz);if(z){let P6=[]';
-const patch1Replace = '$Qz);if(!0){let P6=[]';
+// The z variable retains its original value for passthrough to Tdz.
+const patch1Search = 'vdz);if(z){let H6=[]';
+const patch1Replace = 'vdz);if(!0){let H6=[]';
 
-// Patch 2: Pass verbose prop through nKK -> OQz
-// Adds verbose:z to the OQz createElement call so OQz receives the original
+// Patch 2: Pass verbose prop through main component -> Tdz
+// Adds verbose:z to the Tdz createElement call so Tdz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(OQz,{key:w6.id,content:w6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(OQz,{key:w6.id,content:w6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(Tdz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(Tdz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in OQz component
+// Patch 3: Accept verbose prop in Tdz component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in OQz renderToolResultMessage
+// Patch 4: Use verbose prop in Tdz renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
 const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:A})';
 const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:A})';
 
 const patches = [
-  { name: 'Force nKK verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to OQz', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in OQz', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in OQz results', search: patch4Search, replace: patch4Replace },
+  { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to Tdz', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in Tdz', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in Tdz results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.100');
+  console.log('Claude Code Tool Visibility Patcher v2.1.101');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.100');
+console.log('Claude Code Tool Visibility Patcher v2.1.101');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -184,18 +184,18 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
 // 4-site patch strategy (v2.1.89):
-//   Parent passes verbose:z to nKK. nKK checks if(z) to decide
-//   expanded vs collapsed. OQz (inner renderer) hardcodes verbose:!0 in
-//   renderToolResultMessage. The patch forces nKK's verbose branch while
-//   threading the original verbose value to OQz so renderToolResultMessage
+//   Parent passes verbose:z to PPK. PPK checks if(z) to decide
+//   expanded vs collapsed. COY (inner renderer) hardcodes verbose:!0 in
+//   renderToolResultMessage. The patch forces PPK's verbose branch while
+//   threading the original verbose value to COY so renderToolResultMessage
 //   gets false (condensed) in normal mode and true (expanded) in transcript.
 //
-//   1. nKK verbose branch: force if(z) → if(!0) so individual tool calls
+//   1. PPK verbose branch: force if(z) → if(!0) so individual tool calls
 //      always render. z retains its original value for passthrough.
-//   2. nKK → OQz call: pass verbose:z so OQz receives the original verbose
+//   2. PPK → COY call: pass verbose:z so COY receives the original verbose
 //      value (false=normal, true=transcript).
-//   3. OQz destructuring: accept the new verbose prop as VB.
-//   4. OQz renderToolResultMessage: use VB??!0 so results are condensed in
+//   3. COY destructuring: accept the new verbose prop as VB.
+//   4. COY renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
 // Version history for collapsed_read_search renderer:
@@ -219,26 +219,29 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // v2.1.100: -> RzY, 4-site: verbose check if(z), RzY inner
 //   renderer, z=verbose var, z6=array var, l=key var, context j3Y→LzY
 //   Site 2: theme W→D. Site 3: theme $→w. Site 4: msg V→v, theme $→w.
+// v2.1.101: -> COY, 4-site: verbose check if(z), COY inner
+//   renderer, z=verbose var, q6=array var, a=key var, context LzY→hOY
+//   Main component UXK→PPK. Site 2: key l→a. Sites 3+4 unchanged.
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
 // The z variable retains its original value for passthrough to RzY.
-const patch1Search = 'LzY);if(z){let z6=[]';
-const patch1Replace = 'LzY);if(!0){let z6=[]';
+const patch1Search = 'hOY);if(z){let q6=[]';
+const patch1Replace = 'hOY);if(!0){let q6=[]';
 
-// Patch 2: Pass verbose prop through main component -> RzY
-// Adds verbose:z to the RzY createElement call so RzY receives the original
+// Patch 2: Pass verbose prop through main component -> COY
+// Adds verbose:z to the COY createElement call so COY receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(RzY,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(RzY,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(COY,{key:a.id,content:a,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(COY,{key:a.id,content:a,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in RzY component
+// Patch 3: Accept verbose prop in COY component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in RzY renderToolResultMessage
+// Patch 4: Use verbose prop in COY renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
 const patch4Search = 'renderToolResultMessage?.(v,[],{verbose:!0,tools:z,theme:w})';
@@ -246,9 +249,9 @@ const patch4Replace = 'renderToolResultMessage?.(v,[],{verbose:VB??!0,tools:z,th
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to RzY', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in RzY', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in RzY results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to COY', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in COY', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in COY results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.96');
+  console.log('Claude Code Tool Visibility Patcher v2.1.97');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.96');
+console.log('Claude Code Tool Visibility Patcher v2.1.97');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -216,36 +216,39 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, O6=array var, P6=key var, context Qcz→fiz
 // v2.1.96: -> Vsz, 4-site: verbose check if(z), Vsz inner
 //   renderer, z=verbose var, A6=array var, X6=key var, context fiz→ksz
+// v2.1.97: -> H3Y, 4-site: verbose check if(z), H3Y inner
+//   renderer, z=verbose var, r=array var, l=key var, context ksz→j3Y
+//   Site 2: lookups O→A, theme D→W. Site 3: ids O↔A anim A↔O swap. Site 4: msg k→V.
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to Vsz.
-const patch1Search = 'ksz);if(z){let A6=[]';
-const patch1Replace = 'ksz);if(!0){let A6=[]';
+// The z variable retains its original value for passthrough to H3Y.
+const patch1Search = 'j3Y);if(z){let r=[]';
+const patch1Replace = 'j3Y);if(!0){let r=[]';
 
-// Patch 2: Pass verbose prop through main component -> Vsz
-// Adds verbose:z to the Vsz createElement call so Vsz receives the original
+// Patch 2: Pass verbose prop through main component -> H3Y
+// Adds verbose:z to the H3Y createElement call so H3Y receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Vsz,{key:X6.id,content:X6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(Vsz,{key:X6.id,content:X6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(H3Y,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:W})';
+const patch2Replace = 'createElement(H3Y,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:W,verbose:z})';
 
-// Patch 3: Accept verbose prop in Ziz component
+// Patch 3: Accept verbose prop in H3Y component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:O,shouldAnimate:A,theme:$}=q';
-const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:O,shouldAnimate:A,theme:$,verbose:VB}=q';
+const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:$}=q';
+const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:$,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in Ziz renderToolResultMessage
+// Patch 4: Use verbose prop in H3Y renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:$})';
-const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:$})';
+const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:$})';
+const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,theme:$})';
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to Ziz', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in Ziz', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in Ziz results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to H3Y', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in H3Y', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in H3Y results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.92');
+  console.log('Claude Code Tool Visibility Patcher v2.1.96');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.92');
+console.log('Claude Code Tool Visibility Patcher v2.1.96');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -214,19 +214,21 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, J6=array var, H6=key var
 // v2.1.92: -> Ziz, 4-site: verbose check if(z), Ziz inner
 //   renderer, z=verbose var, O6=array var, P6=key var, context Qcz→fiz
+// v2.1.96: -> Vsz, 4-site: verbose check if(z), Vsz inner
+//   renderer, z=verbose var, A6=array var, X6=key var, context fiz→ksz
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to Ziz.
-const patch1Search = 'fiz);if(z){let O6=[]';
-const patch1Replace = 'fiz);if(!0){let O6=[]';
+// The z variable retains its original value for passthrough to Vsz.
+const patch1Search = 'ksz);if(z){let A6=[]';
+const patch1Replace = 'ksz);if(!0){let A6=[]';
 
-// Patch 2: Pass verbose prop through main component -> Ziz
-// Adds verbose:z to the Ziz createElement call so Ziz receives the original
+// Patch 2: Pass verbose prop through main component -> Vsz
+// Adds verbose:z to the Vsz createElement call so Vsz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Ziz,{key:P6.id,content:P6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(Ziz,{key:P6.id,content:P6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(Vsz,{key:X6.id,content:X6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(Vsz,{key:X6.id,content:X6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
 // Patch 3: Accept verbose prop in Ziz component
 // Adds verbose:VB to the destructuring so it's available in the function body.

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.111');
+  console.log('Claude Code Tool Visibility Patcher v2.1.112');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.111');
+console.log('Claude Code Tool Visibility Patcher v2.1.112');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -232,26 +232,29 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // v2.1.111: -> Q4Y, 4-site: verbose check if(z), Q4Y inner
 //   renderer, z=verbose var, _6=array var, t=key var, context t7Y→U4Y
 //   Main component w$K→UjK. Site 2: inner renderer e7Y→Q4Y. Site 3: unchanged. Site 4: unchanged.
+// v2.1.112: -> d4Y, 4-site: verbose check if(z), d4Y inner
+//   renderer, z=verbose var, _6=array var, t=key var, context U4Y→Q4Y
+//   Site 2: inner renderer Q4Y→d4Y. Sites 3+4 unchanged.
 
-// Patch 1: Force UjK verbose branch (always show individual tool calls)
+// Patch 1: Force main-component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to Q4Y.
-const patch1Search = 'U4Y);if(z){let _6=[]';
-const patch1Replace = 'U4Y);if(!0){let _6=[]';
+// The z variable retains its original value for passthrough to d4Y.
+const patch1Search = 'Q4Y);if(z){let _6=[]';
+const patch1Replace = 'Q4Y);if(!0){let _6=[]';
 
-// Patch 2: Pass verbose prop through UjK -> Q4Y
-// Adds verbose:z to the Q4Y createElement call so Q4Y receives the original
+// Patch 2: Pass verbose prop through to d4Y
+// Adds verbose:z to the d4Y createElement call so d4Y receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Q4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(Q4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(d4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(d4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in Q4Y component
+// Patch 3: Accept verbose prop in d4Y component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in Q4Y renderToolResultMessage
+// Patch 4: Use verbose prop in d4Y renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
 const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:w})';
@@ -259,9 +262,9 @@ const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,th
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to Q4Y', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in Q4Y', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in Q4Y results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to d4Y', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in d4Y', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in d4Y results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.101');
+  console.log('Claude Code Tool Visibility Patcher v2.1.109');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.101');
+console.log('Claude Code Tool Visibility Patcher v2.1.109');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -222,36 +222,40 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // v2.1.101: -> COY, 4-site: verbose check if(z), COY inner
 //   renderer, z=verbose var, q6=array var, a=key var, context LzY→hOY
 //   Main component UXK→PPK. Site 2: key l→a. Sites 3+4 unchanged.
+// v2.1.109: -> Z7Y, 4-site: verbose check if(z), Z7Y inner
+//   renderer, z=verbose var, _6=array var, t=key var, context hOY→D7Y
+//   Main component PPK→w$K. Verbose branch moved into w$K.
+//   Site 2: key a→t, inner renderer COY→Z7Y. Site 3: unchanged. Site 4: msg v→k.
 
-// Patch 1: Force main component verbose branch (always show individual tool calls)
+// Patch 1: Force w$K verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to RzY.
-const patch1Search = 'hOY);if(z){let q6=[]';
-const patch1Replace = 'hOY);if(!0){let q6=[]';
+// The z variable retains its original value for passthrough to Z7Y.
+const patch1Search = 'D7Y);if(z){let _6=[]';
+const patch1Replace = 'D7Y);if(!0){let _6=[]';
 
-// Patch 2: Pass verbose prop through main component -> COY
-// Adds verbose:z to the COY createElement call so COY receives the original
+// Patch 2: Pass verbose prop through w$K -> Z7Y
+// Adds verbose:z to the Z7Y createElement call so Z7Y receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(COY,{key:a.id,content:a,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(COY,{key:a.id,content:a,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(Z7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(Z7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in COY component
+// Patch 3: Accept verbose prop in Z7Y component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in COY renderToolResultMessage
+// Patch 4: Use verbose prop in Z7Y renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(v,[],{verbose:!0,tools:z,theme:w})';
-const patch4Replace = 'renderToolResultMessage?.(v,[],{verbose:VB??!0,tools:z,theme:w})';
+const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:w})';
+const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:w})';
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to COY', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in COY', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in COY results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to Z7Y', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in Z7Y', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in Z7Y results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.90');
+  console.log('Claude Code Tool Visibility Patcher v2.1.91');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.90');
+console.log('Claude Code Tool Visibility Patcher v2.1.91');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -210,26 +210,28 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, P6=array var
 // v2.1.90: nKK -> Tdz, 4-site: verbose check if(z), Tdz inner
 //   renderer, z=verbose var, H6=array var, J6=key var
+// v2.1.91: -> dcz, 4-site: verbose check if(z), dcz inner
+//   renderer, z=verbose var, J6=array var, H6=key var
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to Tdz.
-const patch1Search = 'vdz);if(z){let H6=[]';
-const patch1Replace = 'vdz);if(!0){let H6=[]';
+// The z variable retains its original value for passthrough to dcz.
+const patch1Search = 'Qcz);if(z){let J6=[]';
+const patch1Replace = 'Qcz);if(!0){let J6=[]';
 
-// Patch 2: Pass verbose prop through main component -> Tdz
-// Adds verbose:z to the Tdz createElement call so Tdz receives the original
+// Patch 2: Pass verbose prop through main component -> dcz
+// Adds verbose:z to the dcz createElement call so dcz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Tdz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(Tdz,{key:J6.id,content:J6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(dcz,{key:H6.id,content:H6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(dcz,{key:H6.id,content:H6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in Tdz component
+// Patch 3: Accept verbose prop in dcz component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in Tdz renderToolResultMessage
+// Patch 4: Use verbose prop in dcz renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
 const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:A})';
@@ -237,9 +239,9 @@ const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,th
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to Tdz', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in Tdz', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in Tdz results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to dcz', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in dcz', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in dcz results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.110');
+  console.log('Claude Code Tool Visibility Patcher v2.1.111');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.110');
+console.log('Claude Code Tool Visibility Patcher v2.1.111');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -229,26 +229,29 @@ let content = fs.readFileSync(targetPath, 'utf8');
 // v2.1.110: -> e7Y, 4-site: verbose check if(z), e7Y inner
 //   renderer, z=verbose var, _6=array var, t=key var, context D7Y→t7Y
 //   Site 2: inner renderer Z7Y→e7Y. Site 3: unchanged. Site 4: msg k→V.
+// v2.1.111: -> Q4Y, 4-site: verbose check if(z), Q4Y inner
+//   renderer, z=verbose var, _6=array var, t=key var, context t7Y→U4Y
+//   Main component w$K→UjK. Site 2: inner renderer e7Y→Q4Y. Site 3: unchanged. Site 4: unchanged.
 
-// Patch 1: Force w$K verbose branch (always show individual tool calls)
+// Patch 1: Force UjK verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to e7Y.
-const patch1Search = 't7Y);if(z){let _6=[]';
-const patch1Replace = 't7Y);if(!0){let _6=[]';
+// The z variable retains its original value for passthrough to Q4Y.
+const patch1Search = 'U4Y);if(z){let _6=[]';
+const patch1Replace = 'U4Y);if(!0){let _6=[]';
 
-// Patch 2: Pass verbose prop through w$K -> e7Y
-// Adds verbose:z to the e7Y createElement call so e7Y receives the original
+// Patch 2: Pass verbose prop through UjK -> Q4Y
+// Adds verbose:z to the Q4Y createElement call so Q4Y receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(e7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(e7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(Q4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(Q4Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in e7Y component
+// Patch 3: Accept verbose prop in Q4Y component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in e7Y renderToolResultMessage
+// Patch 4: Use verbose prop in Q4Y renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
 const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:w})';
@@ -256,9 +259,9 @@ const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,th
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to e7Y', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in e7Y', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in e7Y results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to Q4Y', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in Q4Y', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in Q4Y results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.91');
+  console.log('Claude Code Tool Visibility Patcher v2.1.92');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.91');
+console.log('Claude Code Tool Visibility Patcher v2.1.92');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -212,36 +212,38 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, H6=array var, J6=key var
 // v2.1.91: -> dcz, 4-site: verbose check if(z), dcz inner
 //   renderer, z=verbose var, J6=array var, H6=key var
+// v2.1.92: -> Ziz, 4-site: verbose check if(z), Ziz inner
+//   renderer, z=verbose var, O6=array var, P6=key var, context Qcz→fiz
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to dcz.
-const patch1Search = 'Qcz);if(z){let J6=[]';
-const patch1Replace = 'Qcz);if(!0){let J6=[]';
+// The z variable retains its original value for passthrough to Ziz.
+const patch1Search = 'fiz);if(z){let O6=[]';
+const patch1Replace = 'fiz);if(!0){let O6=[]';
 
-// Patch 2: Pass verbose prop through main component -> dcz
-// Adds verbose:z to the dcz createElement call so dcz receives the original
+// Patch 2: Pass verbose prop through main component -> Ziz
+// Adds verbose:z to the Ziz createElement call so Ziz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(dcz,{key:H6.id,content:H6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(dcz,{key:H6.id,content:H6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(Ziz,{key:P6.id,content:P6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(Ziz,{key:P6.id,content:P6,tools:Y,lookups:O,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in dcz component
+// Patch 3: Accept verbose prop in Ziz component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A}=q';
-const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A,verbose:VB}=q';
+const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:O,shouldAnimate:A,theme:$}=q';
+const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:O,shouldAnimate:A,theme:$,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in dcz renderToolResultMessage
+// Patch 4: Use verbose prop in Ziz renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:A})';
-const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:A})';
+const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:$})';
+const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:$})';
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to dcz', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in dcz', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in dcz results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to Ziz', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in Ziz', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in Ziz results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.86');
+  console.log('Claude Code Tool Visibility Patcher v2.1.89');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.86');
+console.log('Claude Code Tool Visibility Patcher v2.1.89');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -179,23 +179,23 @@ if (!fs.existsSync(targetPath)) {
 
 let content = fs.readFileSync(targetPath, 'utf8');
 
-// Tool Visibility Patch (v2.1.86)
+// Tool Visibility Patch (v2.1.89)
 // Shows individual tool calls (with file paths/patterns) instead of collapsed
 // summaries like "Searched for 2 patterns, read 1 file (ctrl+o to expand)".
 //
-// 4-site patch strategy (v2.1.86):
-//   iiY passes verbose:N (where N=w||P) to R_K. R_K checks if(Y) to decide
-//   expanded vs collapsed. hiY (inner renderer) hardcodes verbose:!0 in
-//   renderToolResultMessage. The patch forces R_K's verbose branch while
-//   threading the original verbose value to hiY so renderToolResultMessage
+// 4-site patch strategy (v2.1.89):
+//   Parent passes verbose:z to nKK. nKK checks if(z) to decide
+//   expanded vs collapsed. OQz (inner renderer) hardcodes verbose:!0 in
+//   renderToolResultMessage. The patch forces nKK's verbose branch while
+//   threading the original verbose value to OQz so renderToolResultMessage
 //   gets false (condensed) in normal mode and true (expanded) in transcript.
 //
-//   1. R_K verbose branch: force if(Y) → if(!0) so individual tool calls
-//      always render. Y retains its original value for passthrough.
-//   2. R_K → hiY call: pass verbose:Y so hiY receives the original verbose
+//   1. nKK verbose branch: force if(z) → if(!0) so individual tool calls
+//      always render. z retains its original value for passthrough.
+//   2. nKK → OQz call: pass verbose:z so OQz receives the original verbose
 //      value (false=normal, true=transcript).
-//   3. hiY destructuring: accept the new verbose prop as VB.
-//   4. hiY renderToolResultMessage: use VB??!0 so results are condensed in
+//   3. OQz destructuring: accept the new verbose prop as VB.
+//   4. OQz renderToolResultMessage: use VB??!0 so results are condensed in
 //      normal mode (VB=false) but fully expanded in transcript mode (VB=true).
 //
 // Version history for collapsed_read_search renderer:
@@ -206,36 +206,38 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, F unchanged (useEffect dep), z=verbose var, _6=array var
 // v2.1.86: iiY -> R_K -> hiY, 4-site: R_K verbose check if(Y), hiY inner
 //   renderer, g=useEffect dep, Y=verbose var, X6=array var
+// v2.1.89: nKK -> OQz, 4-site: nKK verbose check if(z), OQz inner
+//   renderer, z=verbose var, P6=array var
 
-// Patch 1: Force R_K verbose branch (always show individual tool calls)
-// Changes the if-condition from using Y (verbose prop) to !0 (always true)
+// Patch 1: Force nKK verbose branch (always show individual tool calls)
+// Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The Y variable retains its original value for passthrough to hiY.
-const patch1Search = ',[g]),Y){let X6=[]';
-const patch1Replace = ',[g]),!0){let X6=[]';
+// The z variable retains its original value for passthrough to OQz.
+const patch1Search = '$Qz);if(z){let P6=[]';
+const patch1Replace = '$Qz);if(!0){let P6=[]';
 
-// Patch 2: Pass verbose prop through R_K -> hiY
-// Adds verbose:Y to the hiY createElement call so hiY receives the original
+// Patch 2: Pass verbose prop through nKK -> OQz
+// Adds verbose:z to the OQz createElement call so OQz receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(hiY,{key:V6.id,content:V6,tools:z,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:P})';
-const patch2Replace = 'createElement(hiY,{key:V6.id,content:V6,tools:z,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:P,verbose:Y})';
+const patch2Search = 'createElement(OQz,{key:w6.id,content:w6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(OQz,{key:w6.id,content:w6,tools:Y,lookups:$,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in hiY component
+// Patch 3: Accept verbose prop in OQz component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:_,tools:Y,lookups:z,inProgressToolUseIDs:A,shouldAnimate:O,theme:$}=q';
-const patch3Replace = '{content:_,tools:Y,lookups:z,inProgressToolUseIDs:A,shouldAnimate:O,theme:$,verbose:VB}=q';
+const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A}=q';
+const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:$,shouldAnimate:O,theme:A,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in hiY renderToolResultMessage
+// Patch 4: Use verbose prop in OQz renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:Y,theme:$})';
-const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:Y,theme:$})';
+const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:A})';
+const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:A})';
 
 const patches = [
-  { name: 'Force R_K verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to hiY', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in hiY', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in hiY results', search: patch4Search, replace: patch4Replace },
+  { name: 'Force nKK verbose branch', search: patch1Search, replace: patch1Replace },
+  { name: 'Pass verbose to OQz', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in OQz', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in OQz results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.97');
+  console.log('Claude Code Tool Visibility Patcher v2.1.100');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.97');
+console.log('Claude Code Tool Visibility Patcher v2.1.100');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -216,39 +216,39 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, O6=array var, P6=key var, context Qcz→fiz
 // v2.1.96: -> Vsz, 4-site: verbose check if(z), Vsz inner
 //   renderer, z=verbose var, A6=array var, X6=key var, context fiz→ksz
-// v2.1.97: -> H3Y, 4-site: verbose check if(z), H3Y inner
-//   renderer, z=verbose var, r=array var, l=key var, context ksz→j3Y
-//   Site 2: lookups O→A, theme D→W. Site 3: ids O↔A anim A↔O swap. Site 4: msg k→V.
+// v2.1.100: -> RzY, 4-site: verbose check if(z), RzY inner
+//   renderer, z=verbose var, z6=array var, l=key var, context j3Y→LzY
+//   Site 2: theme W→D. Site 3: theme $→w. Site 4: msg V→v, theme $→w.
 
 // Patch 1: Force main component verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to H3Y.
-const patch1Search = 'j3Y);if(z){let r=[]';
-const patch1Replace = 'j3Y);if(!0){let r=[]';
+// The z variable retains its original value for passthrough to RzY.
+const patch1Search = 'LzY);if(z){let z6=[]';
+const patch1Replace = 'LzY);if(!0){let z6=[]';
 
-// Patch 2: Pass verbose prop through main component -> H3Y
-// Adds verbose:z to the H3Y createElement call so H3Y receives the original
+// Patch 2: Pass verbose prop through main component -> RzY
+// Adds verbose:z to the RzY createElement call so RzY receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(H3Y,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:W})';
-const patch2Replace = 'createElement(H3Y,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:W,verbose:z})';
+const patch2Search = 'createElement(RzY,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(RzY,{key:l.id,content:l,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in H3Y component
+// Patch 3: Accept verbose prop in RzY component
 // Adds verbose:VB to the destructuring so it's available in the function body.
-const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:$}=q';
-const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:$,verbose:VB}=q';
+const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
+const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in H3Y renderToolResultMessage
+// Patch 4: Use verbose prop in RzY renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:$})';
-const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,theme:$})';
+const patch4Search = 'renderToolResultMessage?.(v,[],{verbose:!0,tools:z,theme:w})';
+const patch4Replace = 'renderToolResultMessage?.(v,[],{verbose:VB??!0,tools:z,theme:w})';
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to H3Y', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in H3Y', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in H3Y results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to RzY', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in RzY', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in RzY results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied

--- a/patch-tool-visibility.js
+++ b/patch-tool-visibility.js
@@ -13,7 +13,7 @@ const showHelp = args.includes('--help') || args.includes('-h');
 
 // Display help
 if (showHelp) {
-  console.log('Claude Code Tool Visibility Patcher v2.1.109');
+  console.log('Claude Code Tool Visibility Patcher v2.1.110');
   console.log('=============================================\n');
   console.log('Usage: node patch-tool-visibility.js [options]\n');
   console.log('Options:');
@@ -30,7 +30,7 @@ if (showHelp) {
   process.exit(0);
 }
 
-console.log('Claude Code Tool Visibility Patcher v2.1.109');
+console.log('Claude Code Tool Visibility Patcher v2.1.110');
 console.log('=============================================\n');
 
 // Helper function to safely execute shell commands
@@ -226,36 +226,39 @@ let content = fs.readFileSync(targetPath, 'utf8');
 //   renderer, z=verbose var, _6=array var, t=key var, context hOY→D7Y
 //   Main component PPK→w$K. Verbose branch moved into w$K.
 //   Site 2: key a→t, inner renderer COY→Z7Y. Site 3: unchanged. Site 4: msg v→k.
+// v2.1.110: -> e7Y, 4-site: verbose check if(z), e7Y inner
+//   renderer, z=verbose var, _6=array var, t=key var, context D7Y→t7Y
+//   Site 2: inner renderer Z7Y→e7Y. Site 3: unchanged. Site 4: msg k→V.
 
 // Patch 1: Force w$K verbose branch (always show individual tool calls)
 // Changes the if-condition from using z (verbose prop) to !0 (always true)
 // so the verbose branch is always entered regardless of mode.
-// The z variable retains its original value for passthrough to Z7Y.
-const patch1Search = 'D7Y);if(z){let _6=[]';
-const patch1Replace = 'D7Y);if(!0){let _6=[]';
+// The z variable retains its original value for passthrough to e7Y.
+const patch1Search = 't7Y);if(z){let _6=[]';
+const patch1Replace = 't7Y);if(!0){let _6=[]';
 
-// Patch 2: Pass verbose prop through w$K -> Z7Y
-// Adds verbose:z to the Z7Y createElement call so Z7Y receives the original
+// Patch 2: Pass verbose prop through w$K -> e7Y
+// Adds verbose:z to the e7Y createElement call so e7Y receives the original
 // verbose value (false in normal mode, true in transcript mode).
-const patch2Search = 'createElement(Z7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
-const patch2Replace = 'createElement(Z7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
+const patch2Search = 'createElement(e7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D})';
+const patch2Replace = 'createElement(e7Y,{key:t.id,content:t,tools:Y,lookups:A,inProgressToolUseIDs:K,shouldAnimate:_,theme:D,verbose:z})';
 
-// Patch 3: Accept verbose prop in Z7Y component
+// Patch 3: Accept verbose prop in e7Y component
 // Adds verbose:VB to the destructuring so it's available in the function body.
 const patch3Search = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w}=q';
 const patch3Replace = '{content:_,tools:z,lookups:Y,inProgressToolUseIDs:A,shouldAnimate:O,theme:w,verbose:VB}=q';
 
-// Patch 4: Use verbose prop in Z7Y renderToolResultMessage
+// Patch 4: Use verbose prop in e7Y renderToolResultMessage
 // Changes hardcoded verbose:!0 to VB??!0 so results are condensed when
 // VB is false (normal mode) but fully expanded when VB is true (transcript).
-const patch4Search = 'renderToolResultMessage?.(k,[],{verbose:!0,tools:z,theme:w})';
-const patch4Replace = 'renderToolResultMessage?.(k,[],{verbose:VB??!0,tools:z,theme:w})';
+const patch4Search = 'renderToolResultMessage?.(V,[],{verbose:!0,tools:z,theme:w})';
+const patch4Replace = 'renderToolResultMessage?.(V,[],{verbose:VB??!0,tools:z,theme:w})';
 
 const patches = [
   { name: 'Force verbose branch', search: patch1Search, replace: patch1Replace },
-  { name: 'Pass verbose to Z7Y', search: patch2Search, replace: patch2Replace },
-  { name: 'Accept verbose in Z7Y', search: patch3Search, replace: patch3Replace },
-  { name: 'Use verbose in Z7Y results', search: patch4Search, replace: patch4Replace },
+  { name: 'Pass verbose to e7Y', search: patch2Search, replace: patch2Replace },
+  { name: 'Accept verbose in e7Y', search: patch3Search, replace: patch3Replace },
+  { name: 'Use verbose in e7Y results', search: patch4Search, replace: patch4Replace },
 ];
 
 // Check which patches can be applied


### PR DESCRIPTION
## Summary

- Adds `patch-tool-visibility.js` — a patch that forces Claude Code to always show individual Read/Glob/Grep tool calls with file paths and search patterns, instead of collapsed summaries like "Read 1 file (ctrl+o to expand)"

## Motivation

Addresses the issue raised in anthropics/claude-code#21151 — collapsed tool results hide which files are being accessed, making it hard to debug, audit, or understand what the agent is doing without manually expanding every tool call.

## How it works

The patch replaces `verbose:w` with `verbose:!0` in the `collapsed_read_search` case of the message renderer, forcing the collapsed group component to always take its verbose code path. This shows each tool call individually:


```
  ✓ Read (path/to/file.js)
  ✓ Grep (some_pattern)
  ✓ Glob (*.ts)
```

  instead of:

```
  Searched for 2 patterns, read 1 file (ctrl+o to expand)
```

## Usage

```bash
node patch-tool-visibility.js              # Apply patch
node patch-tool-visibility.js --dry-run    # Preview
node patch-tool-visibility.js --restore    # Revert
```

🤖 *Patch created by Claude, for Claude — because even AI wants to see what it's reading.*
